### PR TITLE
Renamings - remove test prefix and replace with bench where needed.

### DIFF
--- a/components/prombench/apps/load-generator/main.py
+++ b/components/prombench/apps/load-generator/main.py
@@ -81,9 +81,9 @@ class Querier(object):
         self.step = qg.get("step", "15s")
 
         if self.type == "instant":
-            self.url = "http://prometheus-test-%s.%s:9090/api/v1/query" % (target, namespace)
+            self.url = "http://prometheus-%s.%s:9090/api/v1/query" % (target, namespace)
         else:
-            self.url = "http://prometheus-test-%s.%s:9090/api/v1/query_range" % (target, namespace)
+            self.url = "http://prometheus-%s.%s:9090/api/v1/query_range" % (target, namespace)
 
     def run(self):
         print("run querier %s %s" % (self.target, self.name))

--- a/components/prombench/manifests/benchmark/3_prometheus-bench.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-bench.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: prometheus-test
+  name: prometheus-bench
   namespace: prombench-{{ .PR_NUMBER }}
 data:
   prometheus.yaml: |
@@ -96,23 +96,23 @@ data:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: prometheus-test-{{ normalise .RELEASE }}
+  name: prometheus-{{ normalise .RELEASE }}
   namespace: prombench-{{ .PR_NUMBER }}
   labels:
     app: prometheus
-    prometheus: test-{{ normalise .RELEASE }}
+    prometheus: {{ normalise .RELEASE }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: prometheus
-      prometheus: test-{{ normalise .RELEASE }}
+      prometheus: {{ normalise .RELEASE }}
   template:
     metadata:
       namespace: prombench-{{ .PR_NUMBER }}
       labels:
         app: prometheus
-        prometheus: test-{{ normalise .RELEASE }}
+        prometheus: {{ normalise .RELEASE }}
     spec:
       serviceAccountName: prometheus
       affinity:
@@ -145,7 +145,7 @@ spec:
       volumes:
       - name: config-volume
         configMap:
-          name: prometheus-test
+          name: prometheus-bench
       - name: instance-ssd
         hostPath:
           # /mnt is where GKE keeps it's SSD
@@ -159,11 +159,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-test-{{ normalise .RELEASE }}
+  name: prometheus-{{ normalise .RELEASE }}
   namespace: prombench-{{ .PR_NUMBER }}
   labels:
     app: prometheus
-    prometheus: test-{{ normalise .RELEASE }}
+    prometheus: {{ normalise .RELEASE }}
 spec:
   ports:
   #should be 1 port
@@ -171,28 +171,28 @@ spec:
     port: 9090
   selector:
     app: prometheus
-    prometheus: test-{{ normalise .RELEASE }}
+    prometheus: {{ normalise .RELEASE }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: prometheus-test-pr-{{ .PR_NUMBER }}
+  name: prometheus-pr-{{ .PR_NUMBER }}
   namespace: prombench-{{ .PR_NUMBER }}
   labels:
     app: prometheus
-    prometheus: test-pr-{{ .PR_NUMBER }}
+    prometheus: pr-{{ .PR_NUMBER }}
 spec:
   replicas: 1
   selector:
     matchLabels:
       app: prometheus
-      prometheus: test-pr-{{ .PR_NUMBER }}
+      prometheus: pr-{{ .PR_NUMBER }}
   template:
     metadata:
       namespace: prombench-{{ .PR_NUMBER }}
       labels:
         app: prometheus
-        prometheus: test-pr-{{ .PR_NUMBER }}
+        prometheus: pr-{{ .PR_NUMBER }}
     spec:
       serviceAccountName: prometheus
       affinity:
@@ -220,7 +220,7 @@ spec:
       volumes:
       - name: config-volume
         configMap:
-          name: prometheus-test
+          name: prometheus-bench
       - name: instance-ssd
         hostPath:
           # /mnt is where GKE keeps it's SSD
@@ -234,11 +234,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-test-pr-{{ .PR_NUMBER }}
+  name: prometheus-pr-{{ .PR_NUMBER }}
   namespace: prombench-{{ .PR_NUMBER }}
   labels:
     app: prometheus
-    prometheus: test-pr-{{ .PR_NUMBER }}
+    prometheus: pr-{{ .PR_NUMBER }}
 spec:
   ports:
   #should be 1 port
@@ -246,4 +246,4 @@ spec:
     port: 9090
   selector:
     app: prometheus
-    prometheus: test-pr-{{ .PR_NUMBER }}
+    prometheus: pr-{{ .PR_NUMBER }}

--- a/components/prombench/nodepools.yaml
+++ b/components/prombench/nodepools.yaml
@@ -4,7 +4,7 @@ cluster:
   name: {{ .CLUSTER_NAME }}
   nodepools:
   # These node-pools will be deployed on triggering benchmark
-  - name: prometheus-{{ .PR_NUMBER }}
+  - name: {{ .PR_NUMBER }}-prometheus
     initialnodecount: 2
     config:
       machinetype: n1-highmem-32
@@ -13,7 +13,7 @@ cluster:
       localssdcount: 1  #SSD is used to give fast-lookup to Prometheus servers being benchmarked
       labels:
         isolation: prometheus
-  - name: nodes-{{ .PR_NUMBER }}
+  - name: {{ .PR_NUMBER }}-targets
     initialnodecount: 1
     config:
       machinetype: n1-highmem-32

--- a/temp/prometheus-builder/README.md
+++ b/temp/prometheus-builder/README.md
@@ -7,7 +7,7 @@ Prombench uses this to build binaries for the Pull Request being benchmarked.
 
 #### Kubernetes Pod
 
-A sample deployment config can be found [here](components/prombench/manifests/benchmark/3_prometheus-test.yaml#L176)
+A sample deployment config can be found [here](components/prombench/manifests/benchmark/3_prometheus-bench.yaml#L176)
 
 #### Docker Container
 


### PR DESCRIPTION
the labels would look much better as just 
`pr-4415` and `master` rather than `test-pr-4415` and `test-master`.

I see you used these to separate meta and the tested one, so where needed I replace test with bench to be less confusing. With test it looked like the deployment labels are some temporary holders.