### PR TITLE
renamed nginx-controller port

### DIFF
--- a/components/prow/manifests/nginx-controller.yaml
+++ b/components/prow/manifests/nginx-controller.yaml
@@ -35,7 +35,7 @@ spec:
           initialDelaySeconds: 30
           timeoutSeconds: 5
         ports:
-        - name: default-backend-port
+        - name: backend-port
           containerPort: 8080
         resources:
           limits:
@@ -57,7 +57,7 @@ metadata:
 spec:
   ports:
   - port: 80
-    targetPort: default-backend-port
+    targetPort: backend-port
   selector:
     app: default-http-backend
 ---


### PR DESCRIPTION
This is a change you did when we were troubleshooting why the nginx backend fails.

Seems that everything is working even without it 

So would be nice to find out if we really need it and remove if not.
Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>