### PR TITLE
Add nginx ingress paths for the prometheus versions being benchmarked

### DIFF
--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -829,6 +829,7 @@ spec:
         args: [
           "--config.file=/etc/prometheus/config/prometheus.yaml",
           "--storage.tsdb.path=/data",
+          "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-release"
         ]
         volumeMounts:
         - name: config-volume

--- a/components/prombench/manifests/benchmark/5_nginx-ingress-routes.yaml
+++ b/components/prombench/manifests/benchmark/5_nginx-ingress-routes.yaml
@@ -1,0 +1,20 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: ingress-prometheus
+  namespace: prombench-{{ .PR_NUMBER }}
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+  - http:
+      paths:
+      - backend:
+          serviceName: prometheus-test-{{ normalise .RELEASE }}
+          servicePort: 80
+        path: /{{ .PR_NUMBER }}/prometheus-release
+      - backend:
+          serviceName: prometheus-test-pr-{{ .PR_NUMBER }}
+          servicePort: 80
+        path: /{{ .PR_NUMBER }}/prometheus-pr

--- a/components/prombench/manifests/results/prometheus-meta.yaml
+++ b/components/prombench/manifests/results/prometheus-meta.yaml
@@ -89,8 +89,18 @@ data:
         source_labels: [__meta_kubernetes_pod_label_node]
         target_label: node
       - action: replace
-        target_label: prometheus
         source_labels: [__meta_kubernetes_service_label_prometheus]
+        target_label: prometheus
+      - action: replace
+        source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_service_label_prometheus]
+        regex: prombench-(\d+);test-pr-\d+
+        target_label: __metrics_path__
+        replacement: /${1}/prometheus-pr/metrics
+      - action: replace
+        source_labels: [__meta_kubernetes_namespace,__meta_kubernetes_service_label_prometheus]
+        regex: prombench-(\d+);test-(?:master|v.+)
+        target_label: __metrics_path__
+        replacement: /${1}/prometheus-release/metrics
       - action: replace
         source_labels: [__meta_kubernetes_pod_node_name]
         target_label: nodeName

--- a/temp/prometheus-builder/build.sh
+++ b/temp/prometheus-builder/build.sh
@@ -26,4 +26,4 @@ printf "\n\n>> Starting prometheus\n\n"
              --storage.tsdb.path=/data \
              --web.console.libraries=${DIR}/console_libraries \
              --web.console.templates=${DIR}/consoles \
-	       --web.external-url=http://prombench.prometheus.io/$PR_NUMBER/prometheus-pr
+             --web.external-url=http://prombench.prometheus.io/$PR_NUMBER/prometheus-pr

--- a/temp/prometheus-builder/build.sh
+++ b/temp/prometheus-builder/build.sh
@@ -25,4 +25,5 @@ printf "\n\n>> Starting prometheus\n\n"
 ./prometheus --config.file=/etc/prometheus/config/prometheus.yaml \
              --storage.tsdb.path=/data \
              --web.console.libraries=${DIR}/console_libraries \
-             --web.console.templates=${DIR}/consoles
+             --web.console.templates=${DIR}/consoles \
+	       --web.external-url=http://prombench.prometheus.io/$PR_NUMBER/prometheus-pr


### PR DESCRIPTION
Closes #164 

This exposes the Prometheus version on the following URLs

```
http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-pr
http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-release
```
I will also add these links in the welcome message of prombot.

Signed-off-by: sipian <cs15btech11019@iith.ac.in>