### PR TITLE
Use the default flags in prometheus Dockerfile

### DIFF
--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -4,7 +4,7 @@ metadata:
   name: prometheus-test
   namespace: prombench-{{ .PR_NUMBER }}
 data:
-  prometheus.yaml: |
+  prometheus.yml: |
     global:
       scrape_interval: 5s
 
@@ -750,9 +750,9 @@ spec:
         args: ["{{ .PR_NUMBER }}"]
         volumeMounts:
         - name: config-volume
-          mountPath: /etc/prometheus/config
+          mountPath: /etc/prometheus
         - name: instance-ssd
-          mountPath: /data
+          mountPath: /prometheus
         ports:
         - name: prom-web
           containerPort: 9090
@@ -827,15 +827,13 @@ spec:
         image: quay.io/prometheus/prometheus:{{ .RELEASE }}
         imagePullPolicy: Always
         args: [
-          "--config.file=/etc/prometheus/config/prometheus.yaml",
-          "--storage.tsdb.path=/data",
           "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-release"
         ]
         volumeMounts:
         - name: config-volume
-          mountPath: /etc/prometheus/config
+          mountPath: /etc/prometheus
         - name: instance-ssd
-          mountPath: /data
+          mountPath: /prometheus
         ports:
         - name: prom-web
           containerPort: 9090

--- a/temp/prometheus-builder/build.sh
+++ b/temp/prometheus-builder/build.sh
@@ -22,8 +22,8 @@ printf "\n\n>> Creating prometheus binaries\n\n"
 if ! make build; then printf "ERROR:: Building of binaries failed" && exit 1; fi
 
 printf "\n\n>> Starting prometheus\n\n"
-./prometheus --config.file=/etc/prometheus/config/prometheus.yaml \
-             --storage.tsdb.path=/data \
+./prometheus --config.file=/etc/prometheus/prometheus.yml \
+             --storage.tsdb.path=/prometheus \
              --web.console.libraries=${DIR}/console_libraries \
              --web.console.templates=${DIR}/consoles \
              --web.external-url=http://prombench.prometheus.io/$PR_NUMBER/prometheus-pr


### PR DESCRIPTION
Due to https://github.com/prometheus/prometheus/pull/4796,
prometheus-master was crashing with the error 
`Error parsing commandline arguments: flag 'config.file' cannot be repeated`

Therefore I have left all args to default.
Signed-off-by: sipian <cs15btech11019@iith.ac.in>