### PR TITLE
allow starting prometheus with custom flags passed as bash args

### DIFF
--- a/temp/prometheus-builder/build.sh
+++ b/temp/prometheus-builder/build.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 PR_NUMBER=$1
+FLAGS="${@:2}"
 
 if [ -z "$PR_NUMBER" ]; then echo "ERROR::PR NUMBER is missing in argument" && exit 1; fi
 
@@ -22,7 +23,7 @@ printf "\n\n>> Creating prometheus binaries\n\n"
 if ! make build; then printf "ERROR:: Building of binaries failed" && exit 1; fi
 
 printf "\n\n>> Starting prometheus\n\n"
-./prometheus --config.file=/etc/prometheus/prometheus.yml \
+./prometheus --config.file=/etc/prometheus/prometheus.yml $FLAGS \
              --storage.tsdb.path=/prometheus \
              --web.console.libraries=${DIR}/console_libraries \
              --web.console.templates=${DIR}/consoles \


### PR DESCRIPTION
allows running a build with custom flags like custom retention, block
ranges etc.


these custom flags will be added after starting the test, manually by editing the deployment config file.

for example it is needed to test the new size retention flag in https://github.com/prometheus/prometheus/pull/4230


Signed-off-by: Krasi Georgiev <kgeorgie@redhat.com>