### PR TITLE
add deletion reminder cmd

### DIFF
--- a/cmd/deletion-reminder/Dockerfile
+++ b/cmd/deletion-reminder/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.8
+
+COPY deletion-reminder /deletion-reminder
+
+ENTRYPOINT ["/deletion-reminder"]

--- a/cmd/deletion-reminder/Makefile
+++ b/cmd/deletion-reminder/Makefile
@@ -1,0 +1,14 @@
+DOCKER_TAG = docker.io/prombench/deletion-reminder:1.0.0
+
+build:
+	@go version | grep go1.11 || exit  "Requires golang 1.11 with support for modules!"
+	@GO111MODULE=on GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build -o deletion-reminder github.go reminder.go
+
+clean:
+	@rm deletion-reminder
+
+docker: build
+	@docker build -t $(DOCKER_TAG) .
+	@docker push $(DOCKER_TAG)
+
+.PHONY: build clean docker

--- a/cmd/deletion-reminder/github.go
+++ b/cmd/deletion-reminder/github.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/google/go-github/github"
+	"golang.org/x/oauth2"
+)
+
+type ghClient github.Client
+
+const (
+	owner = "prometheus"
+	repo  = "prometheus"
+)
+
+func NewGHClient(oauthFile string) (*ghClient, error) {
+	oauth, err := ioutil.ReadFile(oauthFile)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(
+		&oauth2.Token{AccessToken: string(oauth)},
+	)
+	tc := oauth2.NewClient(ctx, ts)
+
+	client := ghClient(*github.NewClient(tc))
+	return &client, nil
+}
+
+func (c *ghClient) CreateComment(prNumber int, commentBody string) error {
+
+	comment := github.PullRequestComment{
+		Body: &commentBody,
+	}
+
+	_, _, err := c.PullRequests.CreateComment(context.Background(), owner, repo, prNumber, &comment)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/cmd/deletion-reminder/reminder.go
+++ b/cmd/deletion-reminder/reminder.go
@@ -35,7 +35,7 @@ const (
 	triggerCancelComment = "/benchmark cancel"
 
 	remindAfterHours     = time.Duration(48) * time.Hour  // 2 days
-	autoCancelAfterHours = time.Duration(240) * time.Hour // 10 days
+	autoCancelAfterHours = time.Duration(114) * time.Hour // 6 days
 )
 
 func (c *client) checkNamespaceTimeout(namespace *apiCoreV1.Namespace, nsRunningHours map[string]time.Duration) error {

--- a/cmd/deletion-reminder/reminder.go
+++ b/cmd/deletion-reminder/reminder.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/prombench/pkg/provider/k8s"
+	"gopkg.in/alecthomas/kingpin.v2"
+	apiCoreV1 "k8s.io/api/core/v1"
+)
+
+type client struct {
+	githubClient *ghClient
+	oauthFile    string
+}
+
+const (
+	reminderCommentTemplate = `
+	Benchmarking has been going on this PR for %v. 
+	This is a reminder message to delete the benchmarking once you are done.
+	To stop benchmarking, comment **/benchmark cancel** .
+	`
+
+	deletionCommentTemplate = `
+	Benchmarking has been going on this PR for %v. 
+	Stopping benchmarking now.
+	`
+	triggerCancelComment = "/benchmark cancel"
+
+	remindAfterHours     = time.Duration(48) * time.Hour  // 2 days
+	autoCancelAfterHours = time.Duration(240) * time.Hour // 10 days
+)
+
+func (c *client) checkNamespaceTimeout(namespace *apiCoreV1.Namespace, nsRunningHours map[string]time.Duration) error {
+	name := namespace.Name
+
+	if strings.HasPrefix(name, "prombench-") {
+		prNumber, err := strconv.Atoi(name[len("prombench-"):len(name)])
+		if err != nil {
+			return err
+		}
+
+		runningDuration := time.Since(namespace.CreationTimestamp.Time)
+		_, ok := nsRunningHours[name]
+		if !ok {
+			nsRunningHours[name] = remindAfterHours
+		}
+
+		// Send a github reminder after every `remindAfterHours`.
+		// After `autoCancelAfterHours` has passed, prombot will automatically cancel the benchmark.
+		if runningDuration >= nsRunningHours[name] {
+			reminderComment := fmt.Sprintf(reminderCommentTemplate, runningDuration)
+			log.Printf("Posting Deletion Reminder Comment for %d running for %v (>= %v)", prNumber, runningDuration, nsRunningHours[name])
+			if err := c.githubClient.CreateComment(prNumber, reminderComment); err != nil {
+				log.Printf("Error in posting deletion-reminder comment for %d : %v", prNumber, err)
+			}
+
+			if runningDuration >= autoCancelAfterHours {
+				deletionComment := fmt.Sprintf(deletionCommentTemplate, runningDuration)
+				log.Printf("Posting '/benchmark delete' comment for %d running for %v (>= %v)", prNumber, runningDuration, autoCancelAfterHours)
+				if err := c.githubClient.CreateComment(prNumber, deletionComment); err != nil {
+					log.Printf("Error in posting initiating-benchmark-deletion comment for %d : %v", prNumber, err)
+				}
+
+				if err := c.githubClient.CreateComment(prNumber, triggerCancelComment); err != nil {
+					log.Printf("Error in posting triggerring-benchmark-deletion comment for %d : %v", prNumber, err)
+				}
+			}
+			// Add duration for the next iteration.
+			// If `autoCancelAfterHours` timeout has passed, then this is added to prevent repeated '/benchmark cancel' comments
+			// while namespace is being deleted
+			nsRunningHours[name] = time.Duration(int64(nsRunningHours[name].Hours()+remindAfterHours.Hours())) * time.Hour
+		} else {
+			log.Printf("%d has been running for %v (<= %v)", prNumber, runningDuration, nsRunningHours[name])
+		}
+	}
+	return nil
+}
+
+func (c *client) run(*kingpin.ParseContext) error {
+	log.Printf("Starting Prombench-Reminder-Tool")
+
+	k, k8serr := k8s.New(context.Background(), nil)
+	if k8serr != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrapf(k8serr, "Error creating k8s client inside the k8s cluster."))
+		os.Exit(2)
+	}
+
+	gh, ghErr := NewGHClient(c.oauthFile)
+	if ghErr != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrapf(ghErr, "Error creating GitHub client."))
+		os.Exit(2)
+	}
+
+	c.githubClient = gh
+	nsRunningHours := make(map[string]time.Duration)
+
+	for {
+		runningNs, err := k.GetNameSpaces()
+		if err != nil {
+			fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error fetching namespaces list."))
+		} else {
+			runningNsMap := make(map[string]struct{}) //used to remove deleted namespaces from nsRunningHours
+
+			for _, namespace := range runningNs {
+				if namespace.Status.Phase == apiCoreV1.NamespaceActive {
+					runningNsMap[namespace.Name] = struct{}{}
+					if err := c.checkNamespaceTimeout(&namespace, nsRunningHours); err != nil {
+						fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error checking timeout for namespace %s.", namespace.Name))
+					}
+				}
+			}
+
+			// removing deleted namespaces from nsRunningHours
+			for name := range nsRunningHours {
+				if _, ok := runningNsMap[name]; !ok {
+					delete(nsRunningHours, name)
+				}
+			}
+		}
+		time.Sleep(5 * time.Minute)
+	}
+}
+
+func main() {
+
+	app := kingpin.New(filepath.Base(os.Args[0]), "The Prombench-Reminder tool")
+	app.HelpFlag.Short('h')
+
+	var s client
+
+	k8sApp := app.Command("remind", "Remind a maintainer that a deployment is still running. \nex: ./deletion-reminder remind -f /etc/github/oauth").
+		Action(s.run)
+	k8sApp.Flag("file", "File containing GitHub oauth token.").
+		Required().
+		Short('f').
+		ExistingFileVar(&s.oauthFile)
+
+	if _, err := app.Parse(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing commandline arguments"))
+		app.Usage(os.Args[1:])
+		os.Exit(2)
+	}
+}

--- a/components/prombench/manifests/results/deletion-reminder.yaml
+++ b/components/prombench/manifests/results/deletion-reminder.yaml
@@ -1,0 +1,60 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: deletion-reminder
+---
+#Need to give deletion-reminder access to list namespaces
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: deletion-reminder
+rules:
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name:  deletion-reminder
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: deletion-reminder
+subjects:
+- kind: ServiceAccount
+  name:  deletion-reminder
+  namespace: default
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deletion-reminder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: deletion-reminder
+  template:
+    metadata:
+      labels:
+        app: deletion-reminder
+    spec:
+      serviceAccountName: deletion-reminder
+      containers:
+      - name: deletion-reminder
+        image: docker.io/prombench/deletion-reminder:1.0.0
+        imagePullPolicy: Always
+        args:
+        - "remind"
+        - "-f"
+        - "/etc/github/oauth"
+        volumeMounts:
+        - name: oauth
+          mountPath: /etc/github
+          readOnly: true
+      volumes:
+      - name: oauth
+        secret:
+          secretName: oauth-token

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,8 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/protobuf v1.1.0
 	github.com/google/btree v0.0.0-20180124185431-e89373fe6b4a
+	github.com/google/go-github v17.0.0+incompatible
+	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf
 	github.com/googleapis/gax-go v0.0.0-20180411000000-de2cc08e690b99dd3f7d19937d80d3d54e04682f
 	github.com/googleapis/gnostic v0.2.0

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -203,6 +203,16 @@ func (c *K8s) ResourceDelete(deployments []Resource) error {
 	return nil
 }
 
+// Functions to fetch details of different K8s objects.
+func (c *K8s) GetNameSpaces() ([]apiCoreV1.Namespace, error) {
+	client := c.clt.CoreV1().Namespaces()
+	list, err := client.List(apiMetaV1.ListOptions{})
+	if err != nil {
+		return nil, errors.Wrapf(err, "error listing namespaces.")
+	}
+	return list.Items, nil
+}
+
 // Functions to create different K8s objects.
 func (c *K8s) clusterRoleApply(resource runtime.Object) error {
 	req := resource.(*rbac.ClusterRole)


### PR DESCRIPTION
Closes #31 

This sends a GitHub reminder after every 2 days.
After 10 days have passed, prombot will automatically cancel the benchmark.

Have opened a PR to allow prombot access to delete benchmarks  https://github.com/prometheus/test-infra/pull/10

After review, can test this feature on a `Yolo PR` with smaller timeouts.
Signed-off-by: sipian <cs15btech11019@iith.ac.in>