### PR TITLE
[WIP] Added Restarter - Uses preStop Hook

### DIFF
--- a/cmd/restarter/Dockerfile
+++ b/cmd/restarter/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.8
+
+COPY restarter /restarter
+
+ENTRYPOINT ["/restarter"]

--- a/cmd/restarter/Makefile
+++ b/cmd/restarter/Makefile
@@ -1,7 +1,7 @@
-DOCKER_TAG = docker.io/geekodour/restarter:1.0.0
+DOCKER_TAG = docker.io/geekodour/restarter:graceperiod
 
 build:
-	@go version | grep go1.11 || exit  "Requires golang 1.11 with support for modules!"
+	@go version | grep go1.12 || exit  "Requires golang 1.12 with support for modules!"
 	@GO111MODULE=on GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build restarter.go
 
 clean:

--- a/cmd/restarter/Makefile
+++ b/cmd/restarter/Makefile
@@ -1,0 +1,14 @@
+DOCKER_TAG = docker.io/geekodour/restarter:1.0.0
+
+build:
+	@go version | grep go1.11 || exit  "Requires golang 1.11 with support for modules!"
+	@GO111MODULE=on GOARCH=amd64 CGO_ENABLED=0 GOOS=linux go build restarter.go
+
+clean:
+	@rm restarter
+
+docker: build
+	@docker build -t $(DOCKER_TAG) .
+	@docker push $(DOCKER_TAG)
+
+.PHONY: build clean docker

--- a/cmd/restarter/README.md
+++ b/cmd/restarter/README.md
@@ -1,0 +1,44 @@
+# A cli tool to restart k8s deployments from within a k8s cluster. 
+
+This tool uses [k8s provider](../../pkg/provider/k8s) to restart a deployment
+
+## Build
+The project uses [go modules](https://github.com/golang/go/wiki/Modules) so it requires go with support for modules.
+
+```
+go build restarter.go
+// reads go.mod from the project root and downloads all dependencies.
+```
+
+## RBAC Roles
+The container running this tool should have the following RBAC configuration.
+```
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: loadgen-restarter
+  namespace: prombench
+rules:
+- apiGroups: ["apps"]   #apiVersion of deployment being restarted
+  resources:
+  - deployments
+  verbs: ["get", "list", "update"]
+```
+
+## Usage
+```
+// (Note: These commands should be executed inside a k8s container)
+./restarter -h  // Usage and examples. 
+
+Sample Output of ./restarter help restart :
+
+usage: restarter restart --file=FILE [<flags>]
+
+Restart a Kubernetes deployment object
+ex: ./restarter restart -v NAMESPACE:restart -f 3_prometheus_meta.yaml
+
+Flags:
+  -h, --help           Show context-sensitive help (also try --help-long and --help-man).
+  -f, --file=FILE ...  yaml file or folder that describes the parameters for the deployment.
+  -v, --vars=VARS ...  When provided it will substitute the token holders in the yaml file. Follows the standard golang template formating - {{ .hashStable }}.
+```

--- a/cmd/restarter/restarter.go
+++ b/cmd/restarter/restarter.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	appsV1 "k8s.io/api/apps/v1"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/prombench/pkg/provider/k8s"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type restart struct {
+	k8sClient *k8s.K8s
+}
+
+func new() *restart {
+	k, err := k8s.New(context.Background(), nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error creating k8s client inside the k8s cluster"))
+		os.Exit(2)
+	}
+	return &restart{
+		k8sClient: k,
+	}
+}
+
+func (s *restart) fetchResources(counter int) []k8s.Resource {
+	var k8sResource []k8s.Resource
+
+	for _, deployment := range s.k8sClient.GetResourses() {
+		k8sObjects := make([]runtime.Object, 0)
+
+		for _, resource := range deployment.Objects {
+			if kind := strings.ToLower(resource.GetObjectKind().GroupVersionKind().Kind); kind == "deployment" {
+				req := resource.(*appsV1.Deployment)
+				req.ObjectMeta.Labels["restart_counter"] = fmt.Sprintf("%v", counter)
+				k8sObjects = append(k8sObjects, req.DeepCopyObject())
+			}
+		}
+		if len(k8sObjects) > 0 {
+			k8sResource = append(k8sResource, k8s.Resource{FileName: deployment.FileName, Objects: k8sObjects})
+		}
+	}
+	return k8sResource
+}
+
+func (s *restart) restart(*kingpin.ParseContext) error {
+	log.Printf("Starting Prombench-Restarter")
+
+	reqResources := s.fetchResources(counter)
+	counter := 1
+
+	for {
+		counter++
+		if err := s.k8sClient.ResourceApply(reqResources); err != nil {
+			fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error restarting deployment"))
+		}
+
+		time.Sleep((rand.Intn(20) + 10) * time.Minute)
+	}
+}
+
+func main() {
+
+	app := kingpin.New(filepath.Base(os.Args[0]), "The Prombench-Restarter tool")
+	app.HelpFlag.Short('h')
+
+	s := new()
+
+	k8sApp := app.Command("restart", "Restart a Kubernetes deployment object \nex: ./restarter restart").
+		Action(s.k8sClient.DeploymentsParse).
+		Action(s.restart)
+	k8sApp.Flag("file", "yaml file or folder that describes the parameters for the deployment.").
+		Required().
+		Short('f').
+		ExistingFilesOrDirsVar(&s.k8sClient.DeploymentFiles)
+	k8sApp.Flag("vars", "When provided it will substitute the token holders in the yaml file. Follows the standard golang template formating - {{ .hashStable }}.").
+		Short('v').
+		StringMapVar(&s.k8sClient.DeploymentVars)
+
+	if _, err := app.Parse(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, errors.Wrapf(err, "Error parsing commandline arguments"))
+		app.Usage(os.Args[1:])
+		os.Exit(2)
+	}
+}

--- a/components/prombench/manifests/benchmark/1b_serviceaccount.yaml
+++ b/components/prombench/manifests/benchmark/1b_serviceaccount.yaml
@@ -9,3 +9,9 @@ kind: ServiceAccount
 metadata:
   name: prometheus
   namespace: prombench-{{ .PR_NUMBER }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: loadgen-restarter
+  namespace: prombench-{{ .PR_NUMBER }}

--- a/components/prombench/manifests/benchmark/1c_cluster-role-binding.yaml
+++ b/components/prombench/manifests/benchmark/1c_cluster-role-binding.yaml
@@ -9,6 +9,17 @@ rules:
   - deployments
   verbs: ["get", "list", "update"]
 ---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: loadgen-restarter
+  namespace: prombench-{{ .PR_NUMBER }}
+rules:
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  verbs: ["get", "list", "update"]
+---
 #need to give get/update access to loadgen-scaler
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -22,6 +33,21 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: loadgen-scaler
+  namespace: prombench-{{ .PR_NUMBER }}
+---
+#need to give get/update access to loadgen-restarter
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: loadgen-restarter
+  namespace: prombench-{{ .PR_NUMBER }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: loadgen-restarter
+subjects:
+- kind: ServiceAccount
+  name: loadgen-restarter
   namespace: prombench-{{ .PR_NUMBER }}
 ---
 #Need to give Prometheus servers access to pull metrics

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -753,6 +753,8 @@ metadata:
     prometheus: test-pr-{{ .PR_NUMBER }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: prometheus
@@ -763,6 +765,7 @@ spec:
       labels:
         app: prometheus
         prometheus: test-pr-{{ .PR_NUMBER }}
+        restart_count: "0"
     spec:
       serviceAccountName: prometheus
       affinity:
@@ -849,6 +852,8 @@ metadata:
     prometheus: test-{{ normalise .RELEASE }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: prometheus
@@ -859,6 +864,7 @@ spec:
       labels:
         app: prometheus
         prometheus: test-{{ normalise .RELEASE }}
+        restart_count: "0"
     spec:
       serviceAccountName: prometheus
       affinity:

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -707,6 +707,7 @@ metadata:
   labels:
     app: prometheus
     prometheus: test-pr-{{ .PR_NUMBER }}
+    restart_counter: "0"
 spec:
   replicas: 1
   selector:
@@ -817,6 +818,7 @@ metadata:
   labels:
     app: prometheus
     prometheus: test-{{ normalise .RELEASE }}
+    restart_counter: "0"
 spec:
   replicas: 1
   selector:

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -699,6 +699,50 @@ data:
         target_label: nodeName
 
 ---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: prometeus-builder-volume
+  namespace: prombench-{{ .PR_NUMBER }}
+spec:
+  accessModes:
+    - ReadOnlyMany
+  resources:
+    requests:
+      storage: 100Mi
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: prometheus-builder
+  namespace: prombench-{{ .PR_NUMBER }}
+spec:
+  template:
+    spec:
+      containers:
+      - name: prometheus-builder
+        #image: docker.io/prombench/prometheus-builder:2.0.1
+        image: docker.io/geekodour/prometheus-builder:2.2.0
+        env:
+        - name: PR_NUMBER
+          value: "{{ .PR_NUMBER }}"
+        - name: VOLUME_DIR
+          value: "/prometheus-builder" # same as mountPath
+        volumeMounts:
+        - name: executables
+          mountPath: /prometheus-builder
+      restartPolicy: Never
+      volumes:
+      - name: executables
+        persistentVolumeClaim:
+          claimName: prometeus-builder-volume
+      terminationGracePeriodSeconds: 300
+      nodeSelector:
+        cloud.google.com/gke-nodepool: nodes-{{ .PR_NUMBER }}
+        isolation: none
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -707,7 +751,6 @@ metadata:
   labels:
     app: prometheus
     prometheus: test-pr-{{ .PR_NUMBER }}
-    restart_counter: "0"
 spec:
   replicas: 1
   selector:
@@ -734,33 +777,13 @@ spec:
                 - prometheus
       securityContext:
         runAsUser: 0
-      initContainers:
-      - name: prometheus-builder
-        image: docker.io/prombench/prometheus-builder:2.0.1
-        env:
-        - name: PR_NUMBER
-          value: "{{ .PR_NUMBER }}"
-        - name: VOLUME_DIR
-          value: "/prometheus-builder" # same as mountPath
-        volumeMounts:
-        - name: prometheus-executable
-          mountPath: /prometheus-builder
       containers:
       - name: prometheus
         image: quay.io/prometheus/busybox:latest
         imagePullPolicy: Always
-        # The prometheus-builder takes a while to build
-        # so make sure to start it before the release deployment.
-        # Mark it ready only when prometheus is started.
-        # This way we have the least time difference in the scraped metrics.
-        readinessProbe:
-          tcpSocket:
-            port: 9090
-          initialDelaySeconds: 30
-          periodSeconds: 2
-          failureThreshold: 30
-        command: ["/usr/bin/prometheus"]
+        command: [ "/usr/bin/tini", "--"]
         args: [
+          "/usr/bin/prometheus",
           "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-pr",
           "--storage.tsdb.path=/prometheus",
           "--web.console.libraries=/usr/bin/console_libraries",
@@ -768,12 +791,16 @@ spec:
           "--config.file=/etc/prometheus/prometheus.yml",
           "--log.level=debug"
         ]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "'kill -9 $(pidof prometheus)'"]
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus
         - name: instance-ssd
           mountPath: /prometheus
-        - name: prometheus-executable
+        - name: executables
           mountPath: /usr/bin
         ports:
         - name: prom-web
@@ -785,8 +812,10 @@ spec:
       - name: instance-ssd
         hostPath:
           path: /mnt/disks/ssd0 #gke ssds
-      - name: prometheus-executable
-        emptyDir: {}
+      - name: executables
+        persistentVolumeClaim:
+          claimName: prometeus-builder-volume
+          readOnly: true
       terminationGracePeriodSeconds: 300
       nodeSelector:
         cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}
@@ -818,7 +847,6 @@ metadata:
   labels:
     app: prometheus
     prometheus: test-{{ normalise .RELEASE }}
-    restart_counter: "0"
 spec:
   replicas: 1
   selector:
@@ -849,8 +877,9 @@ spec:
       - name: prometheus
         image: quay.io/prometheus/prometheus:{{ .RELEASE }}
         imagePullPolicy: Always
-        command: [ "/bin/prometheus" ]
+        command: [ "/usr/bin/tini", "--"]
         args: [
+          "/bin/prometheus",
           "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-release",
           "--storage.tsdb.path=/prometheus",
           "--web.console.libraries=/etc/prometheus/console_libraries",
@@ -858,11 +887,17 @@ spec:
           "--config.file=/etc/prometheus/prometheus.yml",
           "--log.level=debug"
         ]
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/bin/sh", "-c", "'kill -9 $(pidof prometheus)'"]
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus
         - name: instance-ssd
           mountPath: /prometheus
+        - name: executables
+          mountPath: /usr/bin
         ports:
         - name: prom-web
           containerPort: 9090
@@ -872,9 +907,11 @@ spec:
           name: prometheus-test
       - name: instance-ssd
         hostPath:
-          # /mnt is where GKE keeps it's SSD
-          # don't change this if you want Prometheus to take advantage of these local SSDs
-          path: /mnt/disks/ssd0
+          path: /mnt/disks/ssd0 #gke ssds
+      - name: executables
+        persistentVolumeClaim:
+          claimName: prometeus-builder-volume
+          readOnly: true
       terminationGracePeriodSeconds: 300
       nodeSelector:
         cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -794,7 +794,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "'kill -9 $(pidof prometheus)'"]
+              command: ["/bin/sh", "-c", "killall -9 prometheus"]
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus
@@ -890,7 +890,7 @@ spec:
         lifecycle:
           preStop:
             exec:
-              command: ["/bin/sh", "-c", "'kill -9 $(pidof prometheus)'"]
+              command: ["/bin/sh", "-c", "killall -9 prometheus"]
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus

--- a/components/prombench/manifests/benchmark/7_restarter.yaml
+++ b/components/prombench/manifests/benchmark/7_restarter.yaml
@@ -15,6 +15,8 @@ data:
         prometheus: test-pr-{{ .PR_NUMBER }}
     spec:
       replicas: 1
+      strategy:
+        type: Recreate
       selector:
         matchLabels:
           app: prometheus
@@ -25,6 +27,7 @@ data:
           labels:
             app: prometheus
             prometheus: test-pr-{{ .PR_NUMBER }}
+            restart_count: "0"
         spec:
           serviceAccountName: prometheus
           affinity:
@@ -93,6 +96,8 @@ data:
         prometheus: test-{{ normalise .RELEASE }}
     spec:
       replicas: 1
+      strategy:
+        type: Recreate
       selector:
         matchLabels:
           app: prometheus
@@ -103,6 +108,7 @@ data:
           labels:
             app: prometheus
             prometheus: test-{{ normalise .RELEASE }}
+            restart_count: "0"
         spec:
           serviceAccountName: prometheus
           affinity:
@@ -121,7 +127,7 @@ data:
           - name: prometheus
             image: quay.io/prometheus/prometheus:{{ .RELEASE }}
             imagePullPolicy: Always
-            command: ["/usr/bin/tini", "--"]
+            command: [ "/usr/bin/tini", "--"]
             args: [
               "/bin/prometheus",
               "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-release",

--- a/components/prombench/manifests/benchmark/7_restarter.yaml
+++ b/components/prombench/manifests/benchmark/7_restarter.yaml
@@ -13,7 +13,6 @@ data:
       labels:
         app: prometheus
         prometheus: test-pr-{{ .PR_NUMBER }}
-        restart_counter: "0"
     spec:
       replicas: 1
       selector:
@@ -42,24 +41,29 @@ data:
             runAsUser: 0
           containers:
           - name: prometheus
-            image: docker.io/prombench/prometheus-builder:2.0.0
+            image: quay.io/prometheus/busybox:latest
             imagePullPolicy: Always
-            # The prometheus-builder takes a while to build and run
-            # so make sure we start it before the release deployment.
-            # Mark it ready only when prometheus is started.
-            # This way we have the least time difference in the scraped metrics.
-            readinessProbe:
-              tcpSocket:
-                port: 9090
-              initialDelaySeconds: 30
-              periodSeconds: 2
-              failureThreshold: 30
-            args: ["{{ .PR_NUMBER }}"]
+            command: [ "/usr/bin/tini", "--"]
+            args: [
+              "/usr/bin/prometheus",
+              "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-pr",
+              "--storage.tsdb.path=/prometheus",
+              "--web.console.libraries=/usr/bin/console_libraries",
+              "--web.console.templates=/usr/bin/consoles",
+              "--config.file=/etc/prometheus/prometheus.yml",
+              "--log.level=debug"
+            ]
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh", "-c", "'kill -9 $(pidof prometheus)'"]
             volumeMounts:
             - name: config-volume
               mountPath: /etc/prometheus
             - name: instance-ssd
               mountPath: /prometheus
+            - name: executables
+              mountPath: /usr/bin
             ports:
             - name: prom-web
               containerPort: 9090
@@ -69,9 +73,11 @@ data:
               name: prometheus-test
           - name: instance-ssd
             hostPath:
-              # /mnt is where GKE keeps it's SSD
-              # don't change this if you want Prometheus to take advantage of these local SSDs
-              path: /mnt/disks/ssd0
+              path: /mnt/disks/ssd0 #gke ssds
+          - name: executables
+            persistentVolumeClaim:
+              claimName: prometeus-builder-volume
+              readOnly: true
           terminationGracePeriodSeconds: 300
           nodeSelector:
             cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}
@@ -85,7 +91,6 @@ data:
       labels:
         app: prometheus
         prometheus: test-{{ normalise .RELEASE }}
-        restart_counter: "0"
     spec:
       replicas: 1
       selector:
@@ -116,8 +121,9 @@ data:
           - name: prometheus
             image: quay.io/prometheus/prometheus:{{ .RELEASE }}
             imagePullPolicy: Always
-            command: [ "/bin/prometheus" ]
+            command: ["/usr/bin/tini", "--"]
             args: [
+              "/bin/prometheus",
               "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-release",
               "--storage.tsdb.path=/prometheus",
               "--web.console.libraries=/etc/prometheus/console_libraries",
@@ -125,11 +131,17 @@ data:
               "--config.file=/etc/prometheus/prometheus.yml",
               "--log.level=debug"
             ]
+            lifecycle:
+              preStop:
+                exec:
+                  command: ["/bin/sh", "-c", "'kill -9 $(pidof prometheus)'"]
             volumeMounts:
             - name: config-volume
               mountPath: /etc/prometheus
             - name: instance-ssd
               mountPath: /prometheus
+            - name: executables
+              mountPath: /usr/bin
             ports:
             - name: prom-web
               containerPort: 9090
@@ -139,13 +151,16 @@ data:
               name: prometheus-test
           - name: instance-ssd
             hostPath:
-              # /mnt is where GKE keeps it's SSD
-              # don't change this if you want Prometheus to take advantage of these local SSDs
-              path: /mnt/disks/ssd0
+              path: /mnt/disks/ssd0 #gke ssds
+          - name: executables
+            persistentVolumeClaim:
+              claimName: prometeus-builder-volume
+              readOnly: true
           terminationGracePeriodSeconds: 300
           nodeSelector:
             cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}
             isolation: prometheus
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -166,7 +181,7 @@ spec:
       serviceAccountName: loadgen-restarter
       containers:
       - name: prom-load-generator
-        image: docker.io/geekodour/restarter:1.0.0
+        image: docker.io/geekodour/restarter:graceperiod
         imagePullPolicy: Always
         args:
         - "restart"
@@ -175,7 +190,7 @@ spec:
         - "-f"
         - "/etc/restarter/prometheus_pr.yaml"
         - "-v"
-        - "PR_NUMBER:{{ .PR_NUMBER }}"        #Used to specify prometheus-test's namespace
+        - "PR_NUMBER:{{ .PR_NUMBER }}"
         volumeMounts:
         - name: prometheus-config-volume
           mountPath: /etc/restarter

--- a/components/prombench/manifests/benchmark/7_restarter.yaml
+++ b/components/prombench/manifests/benchmark/7_restarter.yaml
@@ -1,0 +1,188 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: prometheus-test-config-restarter
+  namespace: prombench-{{ .PR_NUMBER }}
+data:
+  prometheus_pr.yaml: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: prometheus-test-pr-{{ .PR_NUMBER }}
+      namespace: prombench-{{ .PR_NUMBER }}
+      labels:
+        app: prometheus
+        prometheus: test-pr-{{ .PR_NUMBER }}
+        restart_counter: "0"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: prometheus
+          prometheus: test-pr-{{ .PR_NUMBER }}
+      template:
+        metadata:
+          namespace: prombench-{{ .PR_NUMBER }}
+          labels:
+            app: prometheus
+            prometheus: test-pr-{{ .PR_NUMBER }}
+        spec:
+          serviceAccountName: prometheus
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - prometheus
+          securityContext:
+            runAsUser: 0
+          containers:
+          - name: prometheus
+            image: docker.io/prombench/prometheus-builder:2.0.0
+            imagePullPolicy: Always
+            # The prometheus-builder takes a while to build and run
+            # so make sure we start it before the release deployment.
+            # Mark it ready only when prometheus is started.
+            # This way we have the least time difference in the scraped metrics.
+            readinessProbe:
+              tcpSocket:
+                port: 9090
+              initialDelaySeconds: 30
+              periodSeconds: 2
+              failureThreshold: 30
+            args: ["{{ .PR_NUMBER }}"]
+            volumeMounts:
+            - name: config-volume
+              mountPath: /etc/prometheus
+            - name: instance-ssd
+              mountPath: /prometheus
+            ports:
+            - name: prom-web
+              containerPort: 9090
+          volumes:
+          - name: config-volume
+            configMap:
+              name: prometheus-test
+          - name: instance-ssd
+            hostPath:
+              # /mnt is where GKE keeps it's SSD
+              # don't change this if you want Prometheus to take advantage of these local SSDs
+              path: /mnt/disks/ssd0
+          terminationGracePeriodSeconds: 300
+          nodeSelector:
+            cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}
+            isolation: prometheus
+  prometheus_master.yaml: |
+    apiVersion: apps/v1
+    kind: Deployment
+    metadata:
+      name: prometheus-test-{{ normalise .RELEASE }}
+      namespace: prombench-{{ .PR_NUMBER }}
+      labels:
+        app: prometheus
+        prometheus: test-{{ normalise .RELEASE }}
+        restart_counter: "0"
+    spec:
+      replicas: 1
+      selector:
+        matchLabels:
+          app: prometheus
+          prometheus: test-{{ normalise .RELEASE }}
+      template:
+        metadata:
+          namespace: prombench-{{ .PR_NUMBER }}
+          labels:
+            app: prometheus
+            prometheus: test-{{ normalise .RELEASE }}
+        spec:
+          serviceAccountName: prometheus
+          affinity:
+            podAntiAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+              - topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchExpressions:
+                  - key: app
+                    operator: In
+                    values:
+                    - prometheus
+          securityContext:
+            runAsUser: 0
+          containers:
+          - name: prometheus
+            image: quay.io/prometheus/prometheus:{{ .RELEASE }}
+            imagePullPolicy: Always
+            command: [ "/bin/prometheus" ]
+            args: [
+              "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-release",
+              "--storage.tsdb.path=/prometheus",
+              "--web.console.libraries=/etc/prometheus/console_libraries",
+              "--web.console.templates=/etc/prometheus/consoles",
+              "--config.file=/etc/prometheus/prometheus.yml",
+              "--log.level=debug"
+            ]
+            volumeMounts:
+            - name: config-volume
+              mountPath: /etc/prometheus
+            - name: instance-ssd
+              mountPath: /prometheus
+            ports:
+            - name: prom-web
+              containerPort: 9090
+          volumes:
+          - name: config-volume
+            configMap:
+              name: prometheus-test
+          - name: instance-ssd
+            hostPath:
+              # /mnt is where GKE keeps it's SSD
+              # don't change this if you want Prometheus to take advantage of these local SSDs
+              path: /mnt/disks/ssd0
+          terminationGracePeriodSeconds: 300
+          nodeSelector:
+            cloud.google.com/gke-nodepool: prometheus-{{ .PR_NUMBER }}
+            isolation: prometheus
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-loadgen-restarter
+  namespace: prombench-{{ .PR_NUMBER }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: loadgen-restarter
+  template:
+    metadata:
+      namespace: prombench-{{ .PR_NUMBER }}
+      labels:
+        app: loadgen-restarter
+    spec:
+      serviceAccountName: loadgen-restarter
+      containers:
+      - name: prom-load-generator
+        image: docker.io/geekodour/restarter:1.0.0
+        imagePullPolicy: Always
+        args:
+        - "restart"
+        - "-f"
+        - "/etc/restarter/prometheus_master.yaml"
+        - "-f"
+        - "/etc/restarter/prometheus_pr.yaml"
+        - "-v"
+        - "PR_NUMBER:{{ .PR_NUMBER }}"        #Used to specify prometheus-test's namespace
+        volumeMounts:
+        - name: prometheus-config-volume
+          mountPath: /etc/restarter
+      volumes:
+      - name: prometheus-config-volume
+        configMap:
+          name: prometheus-test-config-restarter
+      nodeSelector:
+        cloud.google.com/gke-nodepool: nodes-{{ .PR_NUMBER }}
+        isolation: none

--- a/components/prombench/manifests/benchmark/7_restarter.yaml
+++ b/components/prombench/manifests/benchmark/7_restarter.yaml
@@ -56,7 +56,7 @@ data:
             lifecycle:
               preStop:
                 exec:
-                  command: ["/bin/sh", "-c", "'kill -9 $(pidof prometheus)'"]
+                  command: ["/bin/sh", "-c", "killall -9 prometheus"]
             volumeMounts:
             - name: config-volume
               mountPath: /etc/prometheus
@@ -134,7 +134,7 @@ data:
             lifecycle:
               preStop:
                 exec:
-                  command: ["/bin/sh", "-c", "'kill -9 $(pidof prometheus)'"]
+                  command: ["/bin/sh", "-c", "killall -9 prometheus"]
             volumeMounts:
             - name: config-volume
               mountPath: /etc/prometheus

--- a/temp/prometheus-builder/build.sh
+++ b/temp/prometheus-builder/build.sh
@@ -23,11 +23,20 @@ fi
 
 git checkout pr-branch
 
+# don't build promtool
+sed -i '/promtool/d' .promu.yml
+
 echo ">> Creating prometheus binaries"
 if ! make build; then
     echo "ERROR:: Building of binaries failed"
     exit 1;
 fi
+
+# download tini so that we can run prometheus as child of PID1
+echo ">> Downloading tini init system"
+wget -O $VOLUME_DIR/tini \
+https://github.com/krallin/tini/releases/download/v0.18.0/tini-static
+chmod +x $VOLUME_DIR/tini
 
 echo ">> Copy files to volume"
 cp prometheus               $VOLUME_DIR/prometheus


### PR DESCRIPTION
After setting `terminationGracePeriodSeconds` to `0` in the container `PodSpec` for the deployments, Kubernetes still seems to be sending `SIGTERM`

So used a [preStop hook](https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/#container-hooks) instead. ~But the preStop hook is not getting triggered for some reason, investigating it now.~

As mentioned previously in #180 triggering restarts based on tsdb metrics(whenever a compaction is taking place) is still due.

Also added Job resource, didn't add the `JobDelete` method yet. Now both of the prometheus instances start ~10s apart(when starting) and almost at the same time in subsequent restarts.

Having the pod build prometheus on each pod deployment takes a lot of time and both the instances are not restarted at the same time, Jobs combined with persistent volumes fixes it.

ping @krasi-georgiev 