### PR TITLE
[RDY] Uses custom domain instead of ingress for grafana and prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ nodepool_create:
 resource_apply:
 	$(PROMBENCH_CMD) gke resource apply -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} \
-		-v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} -v DOMAIN_NAME:prombench.prometheus.io \
+		-v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} -v DOMAIN_NAME:${DOMAIN_NAME} \
 		-f components/prombench/manifests/benchmark
 
 resource_delete:

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ nodepool_create:
 resource_apply:
 	$(PROMBENCH_CMD) gke resource apply -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} \
-		-v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} \
+		-v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} -v DOMAIN_NAME:prombench.prometheus.io \
 		-f components/prombench/manifests/benchmark
 
 resource_delete:

--- a/README.md
+++ b/README.md
@@ -42,26 +42,22 @@ export GRAFANA_ADMIN_PASSWORD=password
     -f components/prow/manifests/rbac.yaml -f components/prow/manifests/nginx-controller.yaml
 ```
 
-- Export the nginx-ingress-controller IP address.
+- Export the domain name to an environment variable
 ```
-// Generate auth config so we can use kubectl.
-gcloud container clusters get-credentials $CLUSTER_NAME --zone=$ZONE --project=$PROJECT_ID
-
-kubectl get ingress ing -o go-template='{{ range .status.loadBalancer.ingress}}{{.ip}}{{ end }}'
-
-export INGRESS_IP=$(kubectl get ingress ing -o go-template='{{ range .status.loadBalancer.ingress}}{{.ip}}{{ end }}')
+export DOMAIN_NAME=prombench.prometheus.io
 ```
 
 - Deploy Prometheus-meta & Grafana.
 ```
 ./prombench gke resource apply -a $AUTH_FILE -v PROJECT_ID:$PROJECT_ID \
-    -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME -v INGRESS_IP:$INGRESS_IP \
-    -v GRAFANA_ADMIN_PASSWORD:$GRAFANA_ADMIN_PASSWORD -f components/prombench/manifests/results
+    -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME -v DOMAIN_NAME:$DOMAIN_NAME \
+    -v GRAFANA_ADMIN_PASSWORD:$GRAFANA_ADMIN_PASSWORD \
+    -f components/prombench/manifests/results
 ```
 
 - The services will be accessible at:
-  * Grafana :: http://<INGRESS_IP>/grafana
-  * Prometheus :: http://<INGRESS_IP>/prometheus-meta
+  * Grafana :: http://<DOMAIN_NAME>/grafana
+  * Prometheus :: http://<DOMAIN_NAME>/prometheus-meta
 
 ### Start a test
 ---
@@ -74,16 +70,16 @@ export PR_NUMBER=<PR to benchmark against the selected $RELEASE>
 
 - Create the nodepools for the k8s objects
 ```
-./prombench gke nodepool create -a ${AUTH_FILE} \
-    -v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} \
-    -v PR_NUMBER:${PR_NUMBER} -f components/prombench/nodepools.yaml
+./prombench gke nodepool create -a $AUTH_FILE \
+    -v ZONE:$ZONE -v PROJECT_ID:$PROJECT_ID -v CLUSTER_NAME:$CLUSTER_NAME \
+    -v PR_NUMBER:$PR_NUMBER -f components/prombench/nodepools.yaml
 ```
 
 - Deploy the k8s objects
 ```
-./prombench gke resource apply -a ${AUTH_FILE} \
-    -v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} \
-    -v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} \
+./prombench gke resource apply -a $AUTH_FILE \
+    -v ZONE:$ZONE -v PROJECT_ID:$PROJECT_ID -v CLUSTER_NAME:$CLUSTER_NAME \
+    -v PR_NUMBER:$PR_NUMBER -v RELEASE:$RELEASE -v DOMAIN_NAME:$DOMAIN_NAME \
     -f components/prombench/manifests/benchmark
 ```
 
@@ -125,7 +121,8 @@ export OAUTH_TOKEN=***Replace with the generated token from github***
   * oauth is used when sending requests to the GitHub api.
   * gke auth is used when scaling up and down the cluster.
 ```
-./prombench gke resource apply -a $AUTH_FILE -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME \
+./prombench gke resource apply -a $AUTH_FILE -v ZONE:$ZONE \
+    -v CLUSTER_NAME:$CLUSTER_NAME -v PROJECT_ID:$PROJECT_ID \
     -f components/prow/manifests/secrets.yaml \
     -v HMAC_TOKEN="$(printf $HMAC_TOKEN | base64 -w 0)" \
     -v OAUTH_TOKEN="$(printf $OAUTH_TOKEN | base64 -w 0)" \
@@ -144,7 +141,7 @@ export GITHUB_ORG=prometheus
 export GITHUB_REPO=prometheus
 
 ./prombench gke resource apply -a $AUTH_FILE -v PROJECT_ID:$PROJECT_ID \
-    -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME \
+    -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME -v DOMAIN_NAME:$DOMAIN_NAME \
     -v GITHUB_ORG:$GITHUB_ORG -v GITHUB_REPO:$GITHUB_REPO \
     -f components/prow/manifests/prow_internals_2.yaml
 ```

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ export AUTH_FILE=<path to service-account.json>
 ```
 export GCLOUD_SERVICEACCOUNT_CLIENTID=<client-id present in service-account.json>
 export GRAFANA_ADMIN_PASSWORD=password
+export DOMAIN_NAME=prombench.prometheus.io
 ```
 > The `GCLOUD_SERVICEACCOUNT_CLIENTID` is used to grant cluster-admin-rights to the service-account. This is needed to create RBAC roles on GKE.
 
@@ -40,11 +41,6 @@ export GRAFANA_ADMIN_PASSWORD=password
 ./prombench gke resource apply -a $AUTH_FILE -v PROJECT_ID:$PROJECT_ID -v ZONE:$ZONE \
     -v CLUSTER_NAME:$CLUSTER_NAME -v GCLOUD_SERVICEACCOUNT_CLIENTID:$GCLOUD_SERVICEACCOUNT_CLIENTID \
     -f components/prow/manifests/rbac.yaml -f components/prow/manifests/nginx-controller.yaml
-```
-
-- Export the domain name to an environment variable
-```
-export DOMAIN_NAME=prombench.prometheus.io
 ```
 
 - Deploy Prometheus-meta & Grafana.

--- a/components/prombench/manifests/benchmark/3_prometheus-test.yaml
+++ b/components/prombench/manifests/benchmark/3_prometheus-test.yaml
@@ -760,7 +760,7 @@ spec:
           failureThreshold: 30
         command: ["/usr/bin/prometheus"]
         args: [
-          "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-pr",
+          "--web.external-url=http://{{ .DOMAIN_NAME }}/{{ .PR_NUMBER }}/prometheus-pr",
           "--storage.tsdb.path=/prometheus",
           "--web.console.libraries=/usr/bin/console_libraries",
           "--web.console.templates=/usr/bin/consoles",
@@ -849,7 +849,7 @@ spec:
         imagePullPolicy: Always
         command: [ "/bin/prometheus" ]
         args: [
-          "--web.external-url=http://prombench.prometheus.io/{{ .PR_NUMBER }}/prometheus-release",
+          "--web.external-url=http://{{ .DOMAIN_NAME }}/{{ .PR_NUMBER }}/prometheus-release",
           "--storage.tsdb.path=/prometheus",
           "--web.console.libraries=/etc/prometheus/console_libraries",
           "--web.console.templates=/etc/prometheus/consoles",

--- a/components/prombench/manifests/results/grafana_datasource.yaml
+++ b/components/prombench/manifests/results/grafana_datasource.yaml
@@ -16,7 +16,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://{{ .INGRESS_IP }}/prometheus-meta/
+      url: http://{{ .DOMAIN_NAME }}/prometheus-meta/
       isDefault: true
       jsonData:
          graphiteVersion: "1.1"

--- a/components/prombench/manifests/results/grafana_deployment.yaml
+++ b/components/prombench/manifests/results/grafana_deployment.yaml
@@ -26,7 +26,7 @@ spec:
           - name: GF_PATHS_PROVISIONING
             value: "/opt/grafana-provision"
           - name: GF_SERVER_ROOT_URL
-            value: "http://{{ .INGRESS_IP }}/grafana"
+            value: "http://{{ .DOMAIN_NAME }}/grafana"
           - name: GF_AUTH_ANONYMOUS_ENABLED
             value: "true"
           - name: GF_AUTH_ANONYMOUS_ORG_NAME

--- a/components/prombench/manifests/results/prometheus-meta.yaml
+++ b/components/prombench/manifests/results/prometheus-meta.yaml
@@ -19,7 +19,7 @@ data:
       scrape_interval: 5s
     scrape_configs:
     # prometheus-meta job is added separately because prometheus-meta has a
-    # web.external-url of INGRESS_IP/prometheus-meta/
+    # web.external-url of DOMAIN_NAME/prometheus-meta/
     - job_name: prometheus-meta
       metrics_path: /prometheus-meta/metrics
       static_configs:
@@ -132,7 +132,7 @@ spec:
         - "--config.file=/etc/prometheus/config/prometheus.yaml"
         - "--storage.tsdb.path=/data"
         - "--storage.tsdb.retention=90d"
-        - "--web.external-url=http://{{ .INGRESS_IP }}/prometheus-meta"
+        - "--web.external-url=http://{{ .DOMAIN_NAME }}/prometheus-meta"
         name: prometheus
         volumeMounts:
         - name: config-volume

--- a/components/prow/manifests/prow_internals_2.yaml
+++ b/components/prow/manifests/prow_internals_2.yaml
@@ -188,7 +188,7 @@ metadata:
 data:
   config.yaml: |
     plank:
-      job_url_template: 'http://prombench.prometheus.io/log?job={{"{{"}}.Spec.Job{{"}}"}}&id={{"{{"}}.Status.BuildID{{"}}"}}'
+      job_url_template: 'http://{{ .DOMAIN_NAME }}/log?job={{"{{"}}.Spec.Job{{"}}"}}&id={{"{{"}}.Status.BuildID{{"}}"}}'
       pod_pending_timeout: 60m
       default_decoration_config:
         timeout: 7200000000000 # 2h

--- a/components/prow/manifests/prow_internals_2.yaml
+++ b/components/prow/manifests/prow_internals_2.yaml
@@ -226,6 +226,7 @@ data:
             - "PROJECT_ID={{ .PROJECT_ID }}"
             - "ZONE={{ .ZONE }}"
             - "CLUSTER_NAME={{ .CLUSTER_NAME }}"
+            - "DOMAIN_NAME={{ .DOMAIN_NAME }}"
             volumeMounts:
             - name: serviceaccount
               mountPath: /etc/serviceaccount/


### PR DESCRIPTION
See #77 

- This should allow the domain to be set using the deployment variable `DOMAIN_NAME`
- This also eliminates the use of `INGRESS_IP` in the manifest files and in prombench commands

I've tested this once on whether all the manifest files get applied accordingly. however, I didn't check if there is any change in grafanas behavior. I'll test it soon.


