### PR TITLE
[WIP] Simpleargs cli utility for github actions

### DIFF
--- a/cmd/simpleargs/README.md
+++ b/cmd/simpleargs/README.md
@@ -1,0 +1,27 @@
+# simpleargs
+
+A simple cli intended to be used with GitHub Actions, it takes a regex as the argument and compares it to the body of the `issue_comment`, if matches it writes the matching groups to `/github/home/simpleargs`, otherwise it exits with [error code 78.](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses)
+
+> `/github` is the where GitHub mounts a shared filesystem to be accessed by multiple actions.
+
+## Usage 
+```
+usage: main [<flags>] <regex>
+
+simpleargs github comment extract
+
+Flags:
+  --help  Show context-sensitive help (also try --help-long and --help-man).
+  --eventfile="/github/workflow/event.json"  
+          path to event.json
+  --writepath="/github/home/simpleargs"  
+          path to write args to
+
+Args:
+  <regex>  Regex pattern to match
+```
+
+**Local usage example:**
+```
+./simpleargs --eventfile=./event.json --writepath=./ "^myregex$"
+```

--- a/cmd/simpleargs/README.md
+++ b/cmd/simpleargs/README.md
@@ -1,10 +1,24 @@
 # simpleargs
 
-A simple cli intended to be used with GitHub Actions, it takes a regex as the argument and compares it to the body of the `issue_comment`, if matches it writes the matching groups to `/github/home/simpleargs`, otherwise it exits with [error code 78.](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses)
+A simple cli intended to be used with GitHub Actions, it takes a [RE2 flavour regex](https://github.com/google/re2/wiki/Syntax) as the argument and compares it to the body of the `issue_comment`, if matches it writes the matching groups to `/github/home/simpleargs`, otherwise it exits with [error code 78.](https://developer.github.com/actions/creating-github-actions/accessing-the-runtime-environment/#exit-codes-and-statuses)
+
+The matches can be found inside `/github/home/simpleargs` in the form `ARG0`, `ARG1` and so on.
 
 > `/github` is the where GitHub mounts a shared filesystem to be accessed by multiple actions.
 
-## Usage 
+> **Important Note**
+>
+> GitHub Actions uses the HCL language for the workflow files, it has a [known issue related to
+> backslash](https://github.com/hashicorp/terraform/issues/4052). So, `\` needs to be replaced by
+> `\\` when specifying the argument in the HCL file.
+
+Example:
+```
+normal: (?mi)^/benchmark\s*(master|[0-9]+\.[0-9]+\.[0-9]+\S*)?\s*$
+when using in HCL: (?mi)^/benchmark\\s*(master|[0-9]+\\.[0-9]+\\.[0-9]+\\S*)?\\s*$
+```
+
+## Usage
 ```
 usage: main [<flags>] <regex>
 
@@ -12,9 +26,9 @@ simpleargs github comment extract
 
 Flags:
   --help  Show context-sensitive help (also try --help-long and --help-man).
-  --eventfile="/github/workflow/event.json"  
+  --eventfile="/github/workflow/event.json"
           path to event.json
-  --writepath="/github/home/simpleargs"  
+  --writepath="/github/home/simpleargs"
           path to write args to
 
 Args:

--- a/cmd/simpleargs/main.go
+++ b/cmd/simpleargs/main.go
@@ -18,7 +18,7 @@ var writepath string
 func writeArgs(groups []string) {
 	for i, group := range groups[1:] {
 		data := []byte(group)
-		filename := fmt.Sprintf("ARG%d", i)
+		filename := fmt.Sprintf("ARG_%d", i)
 		err := ioutil.WriteFile(filepath.Join(writepath, filename), data, 0644)
 		if err != nil {
 			log.Fatalln(err)

--- a/cmd/simpleargs/main.go
+++ b/cmd/simpleargs/main.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"fmt"
+	"github.com/google/go-github/v26/github"
+	"gopkg.in/alecthomas/kingpin.v2"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+var regex string
+var eventfile string
+var writepath string
+
+func writeArgs(groups []string) {
+	for i, group := range groups[1:] {
+		data := []byte(group)
+		filename := fmt.Sprintf("ARG%d", i)
+		err := ioutil.WriteFile(filepath.Join(writepath, filename), data, 0644)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+}
+
+func main() {
+	app := kingpin.New(filepath.Base(os.Args[0]), "simpleargs github comment extract")
+	app.Flag("eventfile", "path to event.json").Default("/github/workflow/event.json").StringVar(&eventfile)
+	app.Flag("writepath", "path to write args to").Default("/github/home/simpleargs").StringVar(&writepath)
+	app.Arg("regex", "Regex pattern to match").Required().StringVar(&regex)
+
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	os.MkdirAll(writepath, os.ModePerm)
+	data, err := ioutil.ReadFile(eventfile)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	event, err := github.ParseWebHook("issue_comment", data)
+	if err != nil {
+		log.Fatalln("could not parse = %s\n", err)
+	}
+
+	switch e := event.(type) {
+	case *github.IssueCommentEvent:
+		argRe := regexp.MustCompile(regex)
+		if argRe.MatchString(*e.GetComment().Body) {
+			groups := argRe.FindStringSubmatch(*e.GetComment().Body)
+			writeArgs(groups)
+		} else {
+			log.Printf("matching command not found")
+			os.Exit(78)
+		}
+	default:
+		log.Fatalln("simpleargs only supports issue_comment event")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	cloud.google.com/go v0.39.0
 	github.com/gogo/protobuf v1.2.1 // indirect
+	github.com/google/go-github/v26 v26.0.2 // indirect
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,10 @@ github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-github/v26 v26.0.2 h1:tiPWJNapF2n6Mxbmue/g0uDkSuWf34nzlsNp4Ym7qb8=
+github.com/google/go-github/v26 v26.0.2/go.mod h1:v6/FmX9au22j4CtYxnMhJJkP+JfOQDXALk7hI+MPDNM=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=


### PR DESCRIPTION
This enables comment validation and matching for github comments.

Please see `README.md` for more info.

Currently I just used the binary in the github actions demo, we can create a docker image for this if required.

If tool is accepted I think it should go inside `/third_party` according to this https://github.com/golang-standards/project-layout

ps: very bad at naming tools, please suggest a better name :smile: 