### PR TITLE
Added circleci config to run tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,3 +46,16 @@ jobs:
     - store_artifacts:
         path: .build
         destination: /build
+
+workflows:
+  version: 2
+  prometheus:
+    jobs:
+    - test:
+        filters:
+          tags:
+            only: /.*/
+    - build:
+        filters:
+          tags:
+            only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,6 @@ executors:
 jobs:
   test:
     executor: golang
-
     steps:
     - checkout
     - run: make promu

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,30 +32,11 @@ jobs:
         destination: /build/fake-webserver
     - run: rm -v prombench scaler fake-webserver
 
-  build:
-    machine: true
-
-    steps:
-    - checkout
-    - run: make promu
-    - run: promu crossbuild -v
-    - persist_to_workspace:
-        root: .
-        paths:
-        - .build
-    - store_artifacts:
-        path: .build
-        destination: /build
-
 workflows:
   version: 2
-  prometheus:
+  prombench:
     jobs:
     - test:
-        filters:
-          tags:
-            only: /.*/
-    - build:
         filters:
           tags:
             only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,3 +31,18 @@ jobs:
         path: fake-webserver
         destination: /build/fake-webserver
     - run: rm -v prombench scaler fake-webserver
+
+  build:
+    machine: true
+
+    steps:
+    - checkout
+    - run: make promu
+    - run: promu crossbuild -v
+    - persist_to_workspace:
+        root: .
+        paths:
+        - .build
+    - store_artifacts:
+        path: .build
+        destination: /build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
     - checkout
     - run: make promu
     - run:
-        command: make style unused build
+        command: make style unused vet build
         environment:
           # Run garbage collection more aggresively to avoid getting OOMed during the lint phase.
           GOGC: "20"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,33 @@
+---
+version: 2.1
+
+executors:
+  # Whenever the Go version is updated here, .travis.yml and .promu.yml
+  # should also be updated.
+  golang:
+    docker:
+    - image: circleci/golang:1.12
+
+jobs:
+  test:
+    executor: golang
+
+    steps:
+    - checkout
+    - run: make promu
+    - run:
+        command: make style unused build
+        environment:
+          # Run garbage collection more aggresively to avoid getting OOMed during the lint phase.
+          GOGC: "20"
+    - run: git diff --exit-code
+    - store_artifacts:
+        path: prombench
+        destination: /build/prombench
+    - store_artifacts:
+        path: scaler
+        destination: /build/scaler
+    - store_artifacts:
+        path: fake-webserver
+        destination: /build/fake-webserver
+    - run: rm -v prombench scaler fake-webserver

--- a/.promu.yml
+++ b/.promu.yml
@@ -12,4 +12,8 @@ build:
           path: ./cmd/scaler
         - name: fake-webserver
           path: ./cmd/fake-webserver
-    flags: -a
+    flags: -a -tags netgo
+
+crossbuild:
+    platforms:
+        - linux/amd64


### PR DESCRIPTION
Cont #196 
Closes #177 
Closes #152 

This PR adds circleCI workflow to run basic tests on the prombench repository, the `lint` check was not added because it's failing. 

It'll be good to fix the issues `make lint` is currently showing and then add `lint` to `.circleci/config.yml` in another PR. 