### PR TITLE
[RDY] Updating Grafana to  6.3.0-beta1

### DIFF
--- a/manifests/cluster-infra/grafana_datasource.yaml
+++ b/manifests/cluster-infra/grafana_datasource.yaml
@@ -16,7 +16,7 @@ data:
       type: prometheus
       access: proxy
       orgId: 1
-      url: http://{{ .DOMAIN_NAME }}/prometheus-meta/
+      url: http://prometheus-meta/prometheus-meta/
       isDefault: true
       jsonData:
          graphiteVersion: "1.1"

--- a/manifests/cluster-infra/grafana_deployment.yaml
+++ b/manifests/cluster-infra/grafana_deployment.yaml
@@ -18,6 +18,8 @@ spec:
         component: core
     spec:
       serviceAccountName: prometheus
+      securityContext:
+        runAsUser: 472
       containers:
       - image: grafana/grafana:6.2.5
         name: grafana-core
@@ -27,6 +29,7 @@ spec:
             value: "/opt/grafana-provision"
           - name: GF_SERVER_ROOT_URL
             value: "http://{{ .DOMAIN_NAME }}/grafana"
+            # check if we can use service name here^
           - name: GF_AUTH_ANONYMOUS_ENABLED
             value: "true"
           - name: GF_AUTH_ANONYMOUS_ORG_NAME
@@ -41,7 +44,7 @@ spec:
           timeoutSeconds: 1
         volumeMounts:
         - name: grafana-persistent-storage
-          mountPath: /var
+          mountPath: /var/lib/grafana
         - name: grafana-datasources
           mountPath: /opt/grafana-provision/datasources
         - name: grafana-dashboard-provision
@@ -72,6 +75,7 @@ spec:
       - name: grafana-dashboard-prow
         configMap:
           name: grafana-dashboard-prow
+      # add https://grafana.com/docs/installation/docker/#reading-secrets-from-files-support-for-docker-secrets
       nodeSelector:
         cloud.google.com/gke-nodepool: prow
 ---

--- a/manifests/cluster-infra/grafana_deployment.yaml
+++ b/manifests/cluster-infra/grafana_deployment.yaml
@@ -106,7 +106,8 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     # rewrite-target is required for grafana to work properly in subpath
-    # TODO: remove after upgrading grafana : https://github.com/grafana/grafana/pull/17048
+    # TODO: remove rewrite-target after upgrading grafana to 6.3
+    # https://github.com/grafana/grafana/pull/17048
 spec:
   rules:
   - http:

--- a/manifests/cluster-infra/grafana_deployment.yaml
+++ b/manifests/cluster-infra/grafana_deployment.yaml
@@ -29,13 +29,13 @@ spec:
             value: "/opt/grafana-provision"
           - name: GF_SERVER_ROOT_URL
             value: "http://{{ .DOMAIN_NAME }}/grafana"
-            # check if we can use service name here^
           - name: GF_AUTH_ANONYMOUS_ENABLED
             value: "true"
           - name: GF_AUTH_ANONYMOUS_ORG_NAME
             value: "Main Org."
           - name: GF_SECURITY_ADMIN_PASSWORD
             value: "{{ .GRAFANA_ADMIN_PASSWORD }}"
+          # TODO: https://grafana.com/docs/installation/docker/#reading-secrets-from-files-support-for-docker-secrets
         readinessProbe:
           httpGet:
             path: /login
@@ -75,7 +75,6 @@ spec:
       - name: grafana-dashboard-prow
         configMap:
           name: grafana-dashboard-prow
-      # add https://grafana.com/docs/installation/docker/#reading-secrets-from-files-support-for-docker-secrets
       nodeSelector:
         cloud.google.com/gke-nodepool: prow
 ---

--- a/manifests/cluster-infra/grafana_deployment.yaml
+++ b/manifests/cluster-infra/grafana_deployment.yaml
@@ -35,7 +35,6 @@ spec:
             value: "Main Org."
           - name: GF_SECURITY_ADMIN_PASSWORD
             value: "{{ .GRAFANA_ADMIN_PASSWORD }}"
-          # TODO: https://grafana.com/docs/installation/docker/#reading-secrets-from-files-support-for-docker-secrets
         readinessProbe:
           httpGet:
             path: /login

--- a/manifests/cluster-infra/grafana_deployment.yaml
+++ b/manifests/cluster-infra/grafana_deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       serviceAccountName: prometheus
       containers:
-      - image: grafana/grafana:5.0.0
+      - image: grafana/grafana:6.2.5
         name: grafana-core
         imagePullPolicy: IfNotPresent
         env:
@@ -100,9 +100,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    # rewrite-target is required for grafana to work properly in subpath
-    # TODO: remove after upgrading grafana : https://github.com/grafana/grafana/pull/17048
 spec:
   rules:
   - http:
@@ -110,4 +107,4 @@ spec:
       - backend:
           serviceName: grafana
           servicePort: grafana-web
-        path: /grafana(/|$)(.*)
+        path: /grafana

--- a/manifests/cluster-infra/grafana_deployment.yaml
+++ b/manifests/cluster-infra/grafana_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       securityContext:
         runAsUser: 472
       containers:
-      - image: grafana/grafana:6.2.5
+      - image: grafana/grafana:6.3.0-beta1
         name: grafana-core
         imagePullPolicy: IfNotPresent
         env:
@@ -102,10 +102,6 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
-    nginx.ingress.kubernetes.io/rewrite-target: /$2
-    # rewrite-target is required for grafana to work properly in subpath
-    # TODO: remove rewrite-target after upgrading grafana to 6.3
-    # https://github.com/grafana/grafana/pull/17048
 spec:
   rules:
   - http:
@@ -113,4 +109,4 @@ spec:
       - backend:
           serviceName: grafana
           servicePort: grafana-web
-        path: /grafana(/|$)(.*)
+        path: /

--- a/manifests/cluster-infra/grafana_deployment.yaml
+++ b/manifests/cluster-infra/grafana_deployment.yaml
@@ -104,6 +104,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    # rewrite-target is required for grafana to work properly in subpath
+    # TODO: remove after upgrading grafana : https://github.com/grafana/grafana/pull/17048
 spec:
   rules:
   - http:
@@ -111,4 +114,4 @@ spec:
       - backend:
           serviceName: grafana
           servicePort: grafana-web
-        path: /grafana
+        path: /grafana(/|$)(.*)

--- a/manifests/cluster-infra/grafana_deployment.yaml
+++ b/manifests/cluster-infra/grafana_deployment.yaml
@@ -29,6 +29,8 @@ spec:
             value: "/opt/grafana-provision"
           - name: GF_SERVER_ROOT_URL
             value: "http://{{ .DOMAIN_NAME }}/grafana"
+          - name: GF_SERVER_SERVE_FROM_SUB_PATH
+            value: "true"
           - name: GF_AUTH_ANONYMOUS_ENABLED
             value: "true"
           - name: GF_AUTH_ANONYMOUS_ORG_NAME
@@ -109,4 +111,4 @@ spec:
       - backend:
           serviceName: grafana
           servicePort: grafana-web
-        path: /
+        path: /grafana


### PR DESCRIPTION
This PR updates Grafana to 6.2.5 and performs the migration steps ( https://grafana.com/docs/installation/docker/#migration-from-a-previous-version-of-the-docker-container-to-5-1-or-later ) ~few things still need to be tested.~