### PR TITLE
[RDY] Added `NodePoolCheck` to prombench nodepools cli

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,3 +35,9 @@ nodepool_delete:
 	$(PROMBENCH_CMD) gke nodepool delete -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
 		-f manifests/prombench/nodepools.yaml
+
+nodepool_check:
+	$(PROMBENCH_CMD) gke nodepool check -a ${AUTH_FILE} \
+		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} \
+		-v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
+		-f manifests/prombench/nodepools.yaml

--- a/cmd/prombench/prombench.go
+++ b/cmd/prombench/prombench.go
@@ -47,6 +47,8 @@ func main() {
 		Action(g.NodePoolCreate)
 	k8sGKENodePool.Command("delete", "gke nodepool delete -a service-account.json -f FileOrFolder").
 		Action(g.NodePoolDelete)
+	k8sGKENodePool.Command("check", "gke nodepool check -a service-account.json -f FileOrFolder").
+		Action(g.NodePoolCheck)
 
 	// K8s resource operations.
 	k8sGKEResource := k8sGKE.Command("resource", `Apply and delete different k8s resources - deployments, services, config maps etc.Required variables -v PROJECT_ID, -v ZONE: -west1-b -v CLUSTER_NAME`).

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -426,6 +426,28 @@ func (c *GKE) nodePoolRunning(zone, projectID, clusterID, poolName string) (bool
 	return false, nil
 }
 
+// NodePoolCheck checks if nodepools exists and returns error code if exists
+func (c *GKE) NodePoolCheck(*kingpin.ParseContext) error {
+	reqC := &containerpb.CreateClusterRequest{}
+
+	for _, deployment := range c.gkeResources {
+		if err := yamlGo.UnmarshalStrict(deployment.Content, reqC); err != nil {
+			log.Fatalf("error parsing the cluster deployment file %s:%v", deployment.FileName, err)
+		}
+
+		for _, node := range reqC.Cluster.NodePools {
+			b, err := c.nodePoolRunning(reqC.Zone, reqC.ProjectId, reqC.Cluster.Name, node.Name)
+			if err != nil {
+				log.Fatalln("error fetching nodePool info")
+			}
+			if b == true {
+				log.Fatalln("nodepool exists")
+			}
+		}
+	}
+	return nil
+}
+
 // NewK8sProvider sets the k8s provider used for deploying k8s manifests.
 func (c *GKE) NewK8sProvider(*kingpin.ParseContext) error {
 	projectID, ok := c.DeploymentVars["PROJECT_ID"]

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -440,7 +440,7 @@ func (c *GKE) NodePoolCheck(*kingpin.ParseContext) error {
 			if err != nil {
 				log.Fatalln("error fetching nodePool info")
 			}
-			if b == true {
+			if b {
 				log.Fatalln("nodepool exists")
 			}
 		}

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -426,7 +426,7 @@ func (c *GKE) nodePoolRunning(zone, projectID, clusterID, poolName string) (bool
 	return false, nil
 }
 
-// NodePoolCheck returns an error if all the nodepools do not exist.
+// NodePoolCheck returns an error if any the nodepools do not exist.
 func (c *GKE) NodePoolCheck(*kingpin.ParseContext) error {
 	reqC := &containerpb.CreateClusterRequest{}
 

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -426,7 +426,7 @@ func (c *GKE) nodePoolRunning(zone, projectID, clusterID, poolName string) (bool
 	return false, nil
 }
 
-// NodePoolCheck checks if nodepools exists and returns error code if exists
+// NodePoolCheck returns an error if the nodepool exists.
 func (c *GKE) NodePoolCheck(*kingpin.ParseContext) error {
 	reqC := &containerpb.CreateClusterRequest{}
 


### PR DESCRIPTION
very much work in progress.

* this cli option will enable users to check if nodepools are running or not
* this will be useful when we need to determine whether to start a test based on state of nodepools

Note: I found that this check is necessary for running prombench tests as Deployments when waiting for the previous test to finish before starting a new one when restarting tests.

cc: @krasi-georgiev 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>