### PR TITLE
read the auth data from a file or env variable

### DIFF
--- a/cmd/prombench/prombench.go
+++ b/cmd/prombench/prombench.go
@@ -20,10 +20,10 @@ func main() {
 	g := gke.New()
 	k8sGKE := app.Command("gke", `Google container engine provider - https://cloud.google.com/kubernetes-engine/`).
 		Action(g.NewGKEClient)
-	k8sGKE.Flag("auth", "json authentication file for the project - https://cloud.google.com/iam/docs/creating-managing-service-account-keys. If not set the tool will use the GOOGLE_APPLICATION_CREDENTIALS env variable (export GOOGLE_APPLICATION_CREDENTIALS=service-account.json)").
+	k8sGKE.Flag("auth", "json authentication for the project. Accepts a filepath or an env variable that inlcudes tha json data. If not set the tool will use the GOOGLE_APPLICATION_CREDENTIALS env variable (export GOOGLE_APPLICATION_CREDENTIALS=service-account.json). https://cloud.google.com/iam/docs/creating-managing-service-account-keys.").
 		PlaceHolder("service-account.json").
 		Short('a').
-		ExistingFileVar(&g.AuthFile)
+		StringVar(&g.Auth)
 	k8sGKE.Flag("file", "yaml file or folder  that describes the parameters for the object that will be deployed.").
 		Required().
 		Short('f').

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v0.9.3
 	github.com/spf13/pflag v1.0.3 // indirect
+	google.golang.org/api v0.5.0
 	google.golang.org/genproto v0.0.0-20190516172635-bb713bdc0e52
 	google.golang.org/grpc v1.19.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6


### PR DESCRIPTION
Github actions provide the secrets as env variables and this PR extends prombench to read the json auth data directly from an env variable.

@nikita-mk 	can you please test me and let me know if we need to change anything else.


Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>