### PR TITLE
use the k8s auth from a string

### DIFF
--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/api/option"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	"k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
@@ -470,9 +470,7 @@ func (c *GKE) NewK8sProvider(*kingpin.ParseContext) error {
 	authInfo.AuthProvider = &clientcmdapi.AuthProviderConfig{
 		Name: "gcp",
 		Config: map[string]string{
-			"cmd-args":   "config config-helper --format=json",
-			"expiry-key": "{.credential.token_expiry}",
-			"token-key":  "{.credential.access_token}",
+			gcp.TokenFromString: c.Auth,
 		},
 	}
 
@@ -484,7 +482,7 @@ func (c *GKE) NewK8sProvider(*kingpin.ParseContext) error {
 
 	c.k8sProvider, err = k8sProvider.New(c.ctx, config)
 	if err != nil {
-		log.Fatal("k8s provider error", err)
+		log.Fatal("k8s provider error:", err)
 	}
 	return nil
 }


### PR DESCRIPTION
Will merge when/if my k8s PR is accepted and merged.
https://github.com/kubernetes/kubernetes/pull/80303

Until than need to use the global env variable.

Signed-off-by: Krasi Georgiev <8903888+krasi-georgiev@users.noreply.github.com>