### PR TITLE
Parameters now can be path to file

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -80,6 +80,17 @@ func DeploymentsParse(deploymentFiles []string, deploymentVars map[string]string
 		}
 	}
 
+	for k, v := range deploymentVars {
+		_, err := os.Stat(v)
+		if err == nil && v != "prombench" {
+			val, e := ioutil.ReadFile(v)
+			if e != nil {
+				log.Fatalf("couldn't read var file")
+			}
+			deploymentVars[k] = string(val)
+		}
+	}
+
 	deploymentObjects := make([]Resource, 0)
 	for _, name := range fileList {
 		content, err := applyTemplateVars(name, deploymentVars)


### PR DESCRIPTION
This change will check if the provided parameter is a file path and read its value. The file must contain the value of the parameter.
Does nothing if the parameter is an actual value and not a file path.

Signed-off-by: nikita-mk <nikkikokitkar@gmail.com>