### PR TITLE
kube-state-metrics

### DIFF
--- a/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -51,7 +51,7 @@ data:
         regex: __meta_kubernetes_service_label_(.+)
         replacement: $1
         action: labelmap
-      - source_labels: [__meta_kubernetes_service_label_app]
+      - source_labels: [__meta_kubernetes_service_label_k8s_app]
         separator: ;
         regex: kube-state-metrics
         replacement: $1

--- a/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -39,6 +39,24 @@ data:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+    - job_name: kube-state-metrics
+      honor_timestamps: true
+      scheme: http
+
+      kubernetes_sd_configs:
+      - role: service
+
+      relabel_configs:
+      - separator: ;
+        regex: __meta_kubernetes_service_label_(.+)
+        replacement: $1
+        action: labelmap
+      - source_labels: [__meta_kubernetes_service_label_app]
+        separator: ;
+        regex: kube-state-metrics
+        replacement: $1
+        action: keep
+
     - job_name: cadvisor
       scheme: https
       tls_config:

--- a/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -42,10 +42,8 @@ data:
     - job_name: kube-state-metrics
       honor_timestamps: true
       scheme: http
-
       kubernetes_sd_configs:
       - role: service
-
       relabel_configs:
       - separator: ;
         regex: __meta_kubernetes_service_label_(.+)

--- a/manifests/cluster-infra/4_kube-state-metrics.yaml
+++ b/manifests/cluster-infra/4_kube-state-metrics.yaml
@@ -3,7 +3,6 @@ kind: ServiceAccount
 metadata:
   name: kube-state-metrics
   namespace: kube-system
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -101,6 +100,8 @@ spec:
       containers:
       - name: kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.7.1
+        args:
+        - "--collectors=namespaces"
         ports:
         - name: http-metrics
           containerPort: 8080

--- a/manifests/cluster-infra/4_kube-state-metrics.yaml
+++ b/manifests/cluster-infra/4_kube-state-metrics.yaml
@@ -77,7 +77,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: kube-state-metrics
-namespace: kube-system
+  namespace: kube-system
 
 ---
 apiVersion: apps/v1

--- a/manifests/cluster-infra/4_kube-state-metrics.yaml
+++ b/manifests/cluster-infra/4_kube-state-metrics.yaml
@@ -1,0 +1,137 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - ingresses
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]
+- apiGroups: ["certificates.k8s.io"]
+  resources:
+  - certificatesigningrequests
+  verbs: ["list", "watch"]
+- apiGroups: ["storage.k8s.io"]
+  resources:
+  - storageclasses
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling.k8s.io"]
+  resources:
+  - verticalpodautoscalers
+  verbs: ["list", "watch"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+namespace: kube-system
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: kube-state-metrics
+  name: kube-state-metrics
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-state-metrics
+    spec:
+      serviceAccountName: kube-state-metrics
+      containers:
+      - name: kube-state-metrics
+        image: quay.io/coreos/kube-state-metrics:v1.7.1
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        - name: telemetry
+          containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+  labels:
+    k8s-app: kube-state-metrics
+  annotations:
+    prometheus.io/scrape: 'true'
+spec:
+  ports:
+  - name: http-metrics
+    port: 8080
+    targetPort: http-metrics
+    protocol: TCP
+  - name: telemetry
+    port: 8081
+    targetPort: telemetry
+    protocol: TCP
+  selector:
+    k8s-app: kube-state-metrics
+


### PR DESCRIPTION
closes #76

Adding kube-state-metrics to use the `kube_namespace_created` metric to send alerts to github for long running benchmark tests.

@krasi-georgiev do we need to limit exposed metrics to `kube_namespace_created` only? or for current setup all metrics exposed will be fine? 
https://github.com/kubernetes/kube-state-metrics/blob/master/docs/cli-arguments.md