### PR TITLE
Updated prombench Dockerfile

### DIFF
--- a/cmd/prombench/Dockerfile
+++ b/cmd/prombench/Dockerfile
@@ -1,18 +1,13 @@
 # NOTE: building this requires it to have the build context of the repository root
 
-FROM debian:sid
+FROM golang:1.12-alpine
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
-        apt-utils \
-        build-essential \
-        ca-certificates \
-        make \
-	&& rm -rf /var/lib/apt/lists/*
+RUN apk add --update make
 
 COPY prombench /prombench/prombench
 COPY Makefile /prombench/Makefile
+COPY Makefile.common /prombench/Makefile.common
 COPY manifests/prombench /prombench/manifests/prombench
 
 WORKDIR /prombench


### PR DESCRIPTION
Closes #223 

Updated prombench dockerfile to use golang-alpine base image and install make

This PR adds `Makefile.common`, we can remove this once we are using volume mounted prombench to access the `Makefile`

Secondly it replaces `debian:sid` with `golang:1.12-alpine` because the prombench docker image gives warnings of  the `go` command not found as it's used in various places in the `Makefile.common` and `Makefile` imports `Makefile.common`

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>