### PR TITLE
Fix prombench tests failing due to missing env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ include Makefile.common
 PROMBENCH_CMD        = ./prombench
 
 ifeq ($(AUTH_FILE),)
-AUTH_FILE = "/etc/serviceaccount/service-account.json"
+AUTH_FILE = /etc/serviceaccount/service-account.json
 endif
 
 export GOOGLE_APPLICATION_CREDENTIALS=$(AUTH_FILE)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ ifeq ($(AUTH_FILE),)
 AUTH_FILE = "/etc/serviceaccount/service-account.json"
 endif
 
+export GOOGLE_APPLICATION_CREDENTIALS=$(AUTH_FILE)
+
 .PHONY: deploy clean
 deploy: nodepool_create resource_apply
 clean: resource_delete nodepool_delete


### PR DESCRIPTION
see #222 and #232 

Added `GOOGLE_APPLICATION_CREDENTIALS` to the `Makefile` now prow tests are working as expected.