### PR TITLE
Add github repo cloning to prombench Dockerfile

### DIFF
--- a/cmd/prombench/Dockerfile
+++ b/cmd/prombench/Dockerfile
@@ -1,13 +1,15 @@
 # NOTE: building this requires it to have the build context of the repository root
-
 FROM golang:1.12-alpine
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-RUN apk add --update make
+RUN apk add --update make git
 
-COPY prombench /prombench/prombench
-COPY Makefile /prombench/Makefile
-COPY Makefile.common /prombench/Makefile.common
-COPY manifests/prombench /prombench/manifests/prombench
+ENV PROMBENCH_DIR /prombench
+ENV PROMBENCH_REPO https://github.com/prometheus/prombench.git
 
-WORKDIR /prombench
+COPY prombench /usr/bin/prombench
+COPY cmd/prombench/clone.sh /usr/bin/clone.sh
+
+ENTRYPOINT ["/usr/bin/clone.sh"]
+
+WORKDIR $PROMBENCH_DIR

--- a/cmd/prombench/clone.sh
+++ b/cmd/prombench/clone.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# clone the prombench repo for latest Makefile and manifest files
+git clone $PROMBENCH_REPO $PROMBENCH_DIR
+
+# copy the prombench binary to the cloned directory
+cp /usr/bin/prombench $PROMBENCH_DIR/
+
+# execute arguments passed to the image
+$@

--- a/manifests/prow/components/prow_internals_2.yaml
+++ b/manifests/prow/components/prow_internals_2.yaml
@@ -219,9 +219,8 @@ data:
           containers:
           - image: docker.io/prombench/prombench:2.0.1
             imagePullPolicy: Always
-            command:
-            - "make"
             args:
+            - "make"
             - "deploy"
             - "PROJECT_ID={{ .PROJECT_ID }}"
             - "ZONE={{ .ZONE }}"
@@ -246,9 +245,8 @@ data:
           containers:
           - image: docker.io/prombench/prombench:2.0.1
             imagePullPolicy: Always
-            command:
-            - "make"
             args:
+            - "make"
             - "clean"
             - "PROJECT_ID={{ .PROJECT_ID }}"
             - "ZONE={{ .ZONE }}"


### PR DESCRIPTION
closes #117 

related https://github.com/prometheus/prombench/pull/227#issuecomment-514183277

It avoids cloning and mounting a separate volume to the pod, by adding the cloning of the prombench repository right in the docker image. 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>