### PR TITLE
added eval to clone.sh

### DIFF
--- a/cmd/prombench/clone.sh
+++ b/cmd/prombench/clone.sh
@@ -8,4 +8,5 @@ cp /usr/bin/prombench $PROMBENCH_DIR/
 
 cd $PROMBENCH_DIR
 # execute arguments passed to the image
-$@
+# eval is needed so that bash keywords are not run as commands
+eval "$@"


### PR DESCRIPTION
`while` and `until` which are bash keywords are executed as commands by the prombench image when not using eval. this is required when we want to run a little bit complex bash constructs using the `args` in a k8s `podSpec`

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>