### PR TITLE
Set GOOGLE_APPLICATION_CREDENTIALS as an env var in NewGKEClient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ ifeq ($(AUTH_FILE),)
 AUTH_FILE = /etc/serviceaccount/service-account.json
 endif
 
-export GOOGLE_APPLICATION_CREDENTIALS=$(AUTH_FILE)
-
 .PHONY: deploy clean
 deploy: nodepool_create resource_apply
 clean: resource_delete nodepool_delete

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ export DOMAIN_NAME=prombench.prometheus.io // Can be set to any other custom dom
     -v GKE_AUTH="$(cat $AUTH_FILE | base64 -w 0)" \
     -f manifests/prow/secrets.yaml
 ```
+> Note: Use `-v GKE_AUTH="$(echo $AUTH_FILE | base64 -w 0)"` if you're passing the data directly into `$AUTH_FILE`
 
 - Deploy all internal prow components
 

--- a/README.md
+++ b/README.md
@@ -24,13 +24,10 @@ export PROJECT_ID=<google-cloud project-id>
 export CLUSTER_NAME=prombench
 export ZONE=us-east1-b
 export AUTH_FILE=<path to service-account.json>
-export GOOGLE_APPLICATION_CREDENTIALS=$AUTH_FILE
 
 ./prombench gke cluster create -a $AUTH_FILE -v PROJECT_ID:$PROJECT_ID \
     -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME -f manifests/cluster.yaml
 ```
-
-> `GOOGLE_APPLICATION_CREDENTIALS` is needed for the k8s provider after [#222](https://github.com/prometheus/prombench/pull/222), long term plan is to remove this env var and pass the value of the file directly to the k8s provider.
 
 ### Deploy Prometheus-Meta & Grafana
 > This is used for collecting and displaying the test results.

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -441,6 +441,9 @@ func (c *GKE) NewK8sProvider(*kingpin.ParseContext) error {
 		return fmt.Errorf("missing required CLUSTER_NAME variable")
 	}
 
+	// Set GOOGLE_APPLICATION_CREDENTIALS
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", c.Auth)
+
 	// Get the authentication certificate for the cluster using the GKE client.
 	req := &containerpb.GetClusterRequest{
 		ProjectId: projectID,

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -66,6 +66,7 @@ type GKE struct {
 func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 	// Set the auth env variable needed to the gke client.
 	if c.Auth != "" {
+		os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", c.Auth)
 	} else if c.Auth = os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); c.Auth == "" {
 		log.Fatal("no auth provided! Need to either set the auth flag or the GOOGLE_APPLICATION_CREDENTIALS env variable")
 	}
@@ -440,9 +441,6 @@ func (c *GKE) NewK8sProvider(*kingpin.ParseContext) error {
 	if !ok {
 		return fmt.Errorf("missing required CLUSTER_NAME variable")
 	}
-
-	// Set GOOGLE_APPLICATION_CREDENTIALS
-	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", c.Auth)
 
 	// Get the authentication certificate for the cluster using the GKE client.
 	req := &containerpb.GetClusterRequest{


### PR DESCRIPTION
removed setting of `GOOGLE_APPLICATION_CREDENTIALS` in Makefile and `README.md`