### PR TITLE
move base64 decoding before data is written to the temporary file (NewGKEClient)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,14 @@ export HMAC_TOKEN=$(openssl rand -hex 20)
 - Deploy all internal prow components
 
 ```
+export GITHUB_ORG=prometheus
+export GITHUB_REPO=prometheus
+export PROMBENCH_REPO=https://github.com/prometheus/prombench
+
 ./prombench gke resource apply -a $AUTH_FILE -v PROJECT_ID:$PROJECT_ID \
     -v ZONE:$ZONE -v CLUSTER_NAME:$CLUSTER_NAME -v DOMAIN_NAME:$DOMAIN_NAME \
     -v GITHUB_ORG:$GITHUB_ORG -v GITHUB_REPO:$GITHUB_REPO \
+    -v PROMBENCH_REPO:$PROMBENCH_REPO \
     -f manifests/prow/components
 ```
 

--- a/manifests/prow/components/prow_internals_2.yaml
+++ b/manifests/prow/components/prow_internals_2.yaml
@@ -222,10 +222,17 @@ data:
             args:
             - "make"
             - "deploy"
-            - "PROJECT_ID={{ .PROJECT_ID }}"
-            - "ZONE={{ .ZONE }}"
-            - "CLUSTER_NAME={{ .CLUSTER_NAME }}"
-            - "DOMAIN_NAME={{ .DOMAIN_NAME }}"
+            env:
+            - name: PROJECT_ID
+              value: {{ .PROJECT_ID }}
+            - name: ZONE
+              value: {{ .ZONE }}
+            - name: CLUSTER_NAME
+              value: {{ .CLUSTER_NAME }}
+            - name: DOMAIN_NAME
+              value: {{ .DOMAIN_NAME }}
+            - name: PROMBENCH_REPO
+              value: {{ .PROMBENCH_REPO }}
             volumeMounts:
             - name: serviceaccount
               mountPath: /etc/serviceaccount/
@@ -248,9 +255,15 @@ data:
             args:
             - "make"
             - "clean"
-            - "PROJECT_ID={{ .PROJECT_ID }}"
-            - "ZONE={{ .ZONE }}"
-            - "CLUSTER_NAME={{ .CLUSTER_NAME }}"
+            env:
+            - name: PROJECT_ID
+              value: {{ .PROJECT_ID }}
+            - name: ZONE
+              value: {{ .ZONE }}
+            - name: CLUSTER_NAME
+              value: {{ .CLUSTER_NAME }}
+            - name: PROMBENCH_REPO
+              value: {{ .PROMBENCH_REPO }}
             volumeMounts:
             - name: serviceaccount
               mountPath: /etc/serviceaccount/

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -73,36 +73,35 @@ func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 	// When the auth variable points to a file
 	// put the file content in the variable.
 	if content, err := ioutil.ReadFile(c.Auth); err == nil {
-		// Set the auth env variable needed to the k8s client.
-		// The client looks for this special variable name and it is the only way to set the auth for now.
-		// TODO Remove when the client supports an auth config option in NewDefaultClientConfig.
-		os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", c.Auth)
 		c.Auth = string(content)
-	} else {
-		// Check if auth data is base64 encoded and decode it.
-		encoded, err := regexp.MatchString("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$", c.Auth)
+	}
+
+	// Check if auth data is base64 encoded and decode it.
+	encoded, err := regexp.MatchString("^([A-Za-z0-9+/]{4})*([A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)?$", c.Auth)
+	if err != nil {
+		return err
+	}
+	if encoded {
+		auth, err := base64.StdEncoding.DecodeString(c.Auth)
 		if err != nil {
 			return err
 		}
-		if encoded {
-			auth, err := base64.StdEncoding.DecodeString(c.Auth)
-			if err != nil {
-				return err
-			}
-			c.Auth = string(auth)
-		}
-
-		// Create tempory file to store the credentials.
-		saFile, err := ioutil.TempFile("", "service-account")
-		if err != nil {
-			log.Fatal(err)
-		}
-		defer saFile.Close()
-		if _, err := saFile.Write([]byte(c.Auth)); err != nil {
-			log.Fatal(err)
-		}
-		os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", saFile.Name())
+		c.Auth = string(auth)
 	}
+
+	// Create tempory file to store the credentials.
+	saFile, err := ioutil.TempFile("", "service-account")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer saFile.Close()
+	if _, err := saFile.Write([]byte(c.Auth)); err != nil {
+		log.Fatal(err)
+	}
+	// Set the auth env variable needed to the k8s client.
+	// The client looks for this special variable name and it is the only way to set the auth for now.
+	// TODO: Remove when the client supports an auth config option in NewDefaultClientConfig.
+	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", saFile.Name())
 
 	opts := option.WithCredentialsJSON([]byte(c.Auth))
 

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -84,7 +84,7 @@ func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 	if encoded {
 		auth, err := base64.StdEncoding.DecodeString(c.Auth)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "could not decode auth data")
 		}
 		c.Auth = string(auth)
 	}
@@ -92,11 +92,11 @@ func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 	// Create tempory file to store the credentials.
 	saFile, err := ioutil.TempFile("", "service-account")
 	if err != nil {
-		return err
+		return errors.Wrap(err, "could not create temp file")
 	}
 	defer saFile.Close()
 	if _, err := saFile.Write([]byte(c.Auth)); err != nil {
-		return err
+		return errors.Wrap(err, "could not write to temp file")
 	}
 	// Set the auth env variable needed to the k8s client.
 	// The client looks for this special variable name and it is the only way to set the auth for now.
@@ -107,7 +107,7 @@ func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 
 	cl, err := gke.NewClusterManagerClient(context.Background(), opts)
 	if err != nil {
-		return errors.Errorf("Could not create the gke client: %v", err)
+		return errors.Wrap(err, "could not create the gke client")
 	}
 	c.clientGKE = cl
 	c.ctx = context.Background()

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -67,7 +67,7 @@ func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 	// Set the auth env variable needed to the gke client.
 	if c.Auth != "" {
 	} else if c.Auth = os.Getenv("GOOGLE_APPLICATION_CREDENTIALS"); c.Auth == "" {
-		log.Fatal("no auth provided! Need to either set the auth flag or the GOOGLE_APPLICATION_CREDENTIALS env variable")
+		return errors.Errorf("no auth provided! Need to either set the auth flag or the GOOGLE_APPLICATION_CREDENTIALS env variable")
 	}
 
 	// When the auth variable points to a file
@@ -92,11 +92,11 @@ func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 	// Create tempory file to store the credentials.
 	saFile, err := ioutil.TempFile("", "service-account")
 	if err != nil {
-		log.Fatal(err)
+		return err
 	}
 	defer saFile.Close()
 	if _, err := saFile.Write([]byte(c.Auth)); err != nil {
-		log.Fatal(err)
+		return err
 	}
 	// Set the auth env variable needed to the k8s client.
 	// The client looks for this special variable name and it is the only way to set the auth for now.
@@ -107,7 +107,7 @@ func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 
 	cl, err := gke.NewClusterManagerClient(context.Background(), opts)
 	if err != nil {
-		log.Fatalf("Could not create the client: %v", err)
+		return errors.Errorf("Could not create the gke client: %v", err)
 	}
 	c.clientGKE = cl
 	c.ctx = context.Background()


### PR DESCRIPTION
The file `GOOGLE_APPLICATION_CREDENTIALS` should not be base64 encoded, so we decode it before we write it to the fs.

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>