### PR TITLE
Make docker build succeed for amGithubNotifier after reverting to global go.mod

### DIFF
--- a/tools/amGithubNotifier/Dockerfile
+++ b/tools/amGithubNotifier/Dockerfile
@@ -1,10 +1,14 @@
+# NOTE: building this requires it to have the build context of the repository root
 ARG ARCH="amd64"
 ARG OS="linux"
 
 FROM golang:1.12-alpine AS builder
 ENV GO111MODULE=on
 RUN apk add --update --no-cache git
-COPY . /src
+COPY tools/amGithubNotifier /src
+COPY go.mod /src
+COPY go.sum /src
+
 WORKDIR /src
 RUN go build -a -tags netgo -o /src/build/amGithubNotifier
 

--- a/tools/amGithubNotifier/README.md
+++ b/tools/amGithubNotifier/README.md
@@ -28,7 +28,7 @@ groups:
 ### Example for building the docker image
 From the repository root:
 ```
-$ make docker DOCKERFILE_PATH=tools/amGithubNotifier/Dockerfile DOCKER_IMAGE_NAME=amGithubNotifier DOCKER_IMAGE_TAG=0.0.1
+$ make docker DOCKERFILE_PATH=tools/amGithubNotifier/Dockerfile DOCKER_IMAGE_NAME=amgithubnotifier DOCKER_IMAGE_TAG=0.0.1
 ```
 
 #### Usage and examples:


### PR DESCRIPTION
Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>