### PR TITLE
[RDY] Custom wait for prombench in StatefulSet

### DIFF
--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -465,8 +465,8 @@ func (c *K8s) statefulSetApply(resource runtime.Object) error {
 	// set annotations
 	retryCount := provider.GlobalRetryCount
 	waitOnUpdate := false
-	if count, ok := req.Annotations["prometheus.io/prombench.retry_count"]; ok {
-		intCount, err := strconv.Atoi(count)
+	if c, ok := req.Annotations["prometheus.io/prombench.retry_count"]; ok {
+		intCount, err := strconv.Atoi(c)
 		if err != nil {
 			return fmt.Errorf("%v: format of .retry_count annotation wrong", err)
 		}

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -463,9 +463,7 @@ func (c *K8s) statefulSetApply(resource runtime.Object) error {
 	}
 
 	// set annotations
-	var retryCount int
-
-	retryCount = provider.GlobalRetryCount
+	retryCount := provider.GlobalRetryCount
 	if count, ok := req.Annotations["prometheus.io/prombench.retry_count"]; ok {
 		intCount, err := strconv.Atoi(count)
 		if err != nil {

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -510,7 +510,8 @@ func (c *K8s) statefulSetApply(resource runtime.Object) error {
 			if waitOnUpdate {
 				return provider.RetryUntilTrue(
 					fmt.Sprintf("applying statefulSet:%v", req.Name),
-					retryCount,
+					// For preStop hook, double the retry count
+					2*retryCount,
 					func() (bool, error) { return c.statefulSetReady(resource) })
 			}
 			return nil

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -495,7 +495,11 @@ func (c *K8s) statefulSetApply(resource runtime.Object) error {
 
 	return provider.RetryUntilTrue(
 		fmt.Sprintf("applying statefulSet:%v", req.Name),
-		6*provider.GlobalRetryCount, // StatefulSet used to start test
+		// 6*30(times)*10(seconds) = 30 minutes of wait time
+		// because StatefulSet is used to start and cleanup Prombench tests
+		// If a test fails, users will be notified after 30 minutes
+		// TODO: Make this be set dynamically
+		6*provider.GlobalRetryCount,
 		func() (bool, error) { return c.statefulSetReady(resource) })
 }
 

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -185,6 +185,9 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 			}
 			if err != nil {
 				log.Printf("error applying '%v' err:%v \n", deployment.FileName, err)
+				if provider.ExitOnError {
+					return err
+				}
 			}
 		}
 	}
@@ -490,6 +493,12 @@ func (c *K8s) statefulSetApply(resource runtime.Object) error {
 		log.Printf("resource created - kind: %v, name: %v", kind, req.Name)
 	default:
 		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
+	}
+
+	if exitOnError, ok := req.Annotations["prometheus.io/prombench.exit_on_error"]; ok {
+		if exitOnError == "true" {
+			provider.ExitOnError = true
+		}
 	}
 
 	retryCount := provider.GlobalRetryCount

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -31,10 +31,6 @@ const (
 	globalRetryTime  = 10 * time.Second
 )
 
-var (
-	ExitOnError = false
-)
-
 // Resource holds the file content after parsing the template variables.
 type Resource struct {
 	FileName string

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -44,11 +44,11 @@ type Resource struct {
 // RetryUntilTrue returns when there is an error or the requested operation returns true.
 func RetryUntilTrue(name string, retryCount int, fn func() (bool, error)) error {
 	for i := 1; i <= retryCount; i++ {
+		time.Sleep(globalRetryTime)
 		if ready, err := fn(); err != nil {
 			return err
 		} else if !ready {
 			log.Printf("Request for '%v' is in progress. Checking in %v", name, globalRetryTime)
-			time.Sleep(globalRetryTime)
 			continue
 		}
 		log.Printf("Request for '%v' is done!", name)

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -31,6 +31,10 @@ const (
 	globalRetryTime  = 10 * time.Second
 )
 
+var (
+	ExitOnError = false
+)
+
 // Resource holds the file content after parsing the template variables.
 type Resource struct {
 	FileName string

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -4,8 +4,6 @@ metadata:
   name: prombench-test-{{ .PR_NUMBER }}
   labels:
     app: prombench-test-{{ .PR_NUMBER }}
-  annotations:
-    prometheus.io/prombench.retry_count: '90'
 spec:
   replicas: 1
   selector:

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -42,7 +42,7 @@ spec:
         image: docker.io/prombench/prombench:2.0.2
         imagePullPolicy: Always
         args:
-        # - Create /tmp/READY to marmake k the StatefulSet as ready once make deploy succeeds
+        # - Create /tmp/READY to mark the StatefulSet as ready once make deploy succeeds
         # - /tmp/READY is used in readiness probe
         # - Sleep forever after make deploy succeededs.
         - "make deploy && touch /tmp/READY && echo 'deploy succeeded, now sleeping' && while sleep 86400; do :; done"

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -81,6 +81,9 @@ spec:
             - cat
             - /tmp/READY
           initialDelaySeconds: 300 # 5 mins
+          # Period and Threshold combined should be less than pkg/provider/globalRetryTime
+          periodSeconds: 5
+          failureThreshold: 1
         volumeMounts:
         - name: serviceaccount
           mountPath: /etc/serviceaccount/

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -20,7 +20,7 @@ spec:
         image: docker.io/prombench/prombench:2.0.2
         imagePullPolicy: Always
         args:
-        # wait until all_nodepools_deleted returns a success code then exit
+        # Wait until all_nodepools_deleted returns a success code then exit
         - "until make all_nodepools_deleted; do echo waiting for nodepools to be deleted; sleep 10; done;"
         volumeMounts:
         - name: serviceaccount
@@ -42,7 +42,8 @@ spec:
         image: docker.io/prombench/prombench:2.0.2
         imagePullPolicy: Always
         args:
-        # Create /tmp/READY for readiness check and sleep forever after make deploy succeededs.
+        # - Create /tmp/READY to marmake k the StatefulSet as ready once make deploy succeeds
+        # - Sleep forever after make deploy succeededs.
         - "make deploy && touch /tmp/READY && echo 'deploy succeeded, now sleeping' && while sleep 86400; do :; done"
         env:
           - name: PROJECT_ID
@@ -69,11 +70,14 @@ spec:
               command:
               - "/bin/sh"
               - "-c"
+              # - Delete /tmp/READY to mark the StatefulSet as un-ready before cleanup
+              # - Sleep until all_nodepools_running returns a success code
+              # - Then run make clean and kill the container.
               - "rm /tmp/READY && until make all_nodepools_running; do echo waiting for nodepools to be created; sleep 10; done; make clean; kill -9 -1"
-              # Remove ready status, wait until all_nodepools_running returns a success code then run make clean and kill the container.
         readinessProbe:
           exec:
             command:
+            # successful cat /tmp/READY marks the pod ready
             - cat
             - /tmp/READY
           # Period and Threshold combined should be less than pkg/provider/globalRetryTime.

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -42,7 +42,7 @@ spec:
         image: docker.io/prombench/prombench:2.0.2
         imagePullPolicy: Always
         args:
-        # sleep forever after make deploy succeeded
+        # Create /tmp/READY for readiness check and sleep forever after make deploy succeededs.
         - "make deploy && touch /tmp/READY && echo 'deploy succeeded, now sleeping' && while sleep 86400; do :; done"
         env:
           - name: PROJECT_ID
@@ -70,13 +70,13 @@ spec:
               - "/bin/sh"
               - "-c"
               - "rm /tmp/READY && until make all_nodepools_running; do echo waiting for nodepools to be created; sleep 10; done; make clean; kill -9 -1"
-              # wait until all_nodepools_running returns a success code then run make clean and kill the container
+              # Remove ready status, wait until all_nodepools_running returns a success code then run make clean and kill the container.
         readinessProbe:
           exec:
             command:
             - cat
             - /tmp/READY
-          # Period and Threshold combined should be less than pkg/provider/globalRetryTime
+          # Period and Threshold combined should be less than pkg/provider/globalRetryTime.
           periodSeconds: 5
           failureThreshold: 1
         volumeMounts:

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -80,7 +80,7 @@ spec:
             command:
             - cat
             - /tmp/READY
-          initialDelaySeconds: 600 # 10 mins
+          initialDelaySeconds: 300 # 5 mins
         volumeMounts:
         - name: serviceaccount
           mountPath: /etc/serviceaccount/

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -80,7 +80,6 @@ spec:
             command:
             - cat
             - /tmp/READY
-          initialDelaySeconds: 300 # 5 mins
           # Period and Threshold combined should be less than pkg/provider/globalRetryTime
           periodSeconds: 5
           failureThreshold: 1

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -5,9 +5,9 @@ metadata:
   labels:
     app: prombench-test-{{ .PR_NUMBER }}
   annotations:
-    prometheus.io/prombench.exit_on_error: true
-    prometheus.io/prombench.wait_on_update: true
-    prometheus.io/prombench.retry_count: 60
+    prometheus.io/prombench.exit_on_error: 'true'
+    prometheus.io/prombench.wait_on_update: 'true'
+    prometheus.io/prombench.retry_count: '60'
 spec:
   replicas: 1
   selector:
@@ -78,7 +78,7 @@ spec:
         readinessProbe:
           exec:
             command:
-            - stat -t
+            - cat
             - /tmp/READY
           initialDelaySeconds: 600 # 10 mins
         volumeMounts:

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -4,6 +4,10 @@ metadata:
   name: prombench-test-{{ .PR_NUMBER }}
   labels:
     app: prombench-test-{{ .PR_NUMBER }}
+  annotations:
+    prometheus.io/prombench.exit_on_error: true
+    prometheus.io/prombench.wait_on_update: true
+    prometheus.io/prombench.retry_count: 60
 spec:
   replicas: 1
   selector:
@@ -43,7 +47,7 @@ spec:
         imagePullPolicy: Always
         args:
         # sleep forever after make deploy succeeded
-        - "make deploy && echo 'deploy succeeded, now sleeping' && while sleep 86400; do :; done"
+        - "make deploy && touch /tmp/READY && echo 'deploy succeeded, now sleeping' && while sleep 86400; do :; done"
         env:
           - name: PROJECT_ID
             value: "{{ .PROJECT_ID }}"
@@ -69,8 +73,14 @@ spec:
               command:
               - "/bin/sh"
               - "-c"
-              - "until make all_nodepools_running; do echo waiting for nodepools to be created; sleep 10; done; make clean; kill -9 -1"
+              - "rm /tmp/READY && until make all_nodepools_running; do echo waiting for nodepools to be created; sleep 10; done; make clean; kill -9 -1"
               # wait until all_nodepools_running returns a success code then run make clean and kill the container
+        readinessProbe:
+          exec:
+            command:
+            - stat -t
+            - /tmp/READY
+          initialDelaySeconds: 600 # 10 mins
         volumeMounts:
         - name: serviceaccount
           mountPath: /etc/serviceaccount/

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -7,7 +7,7 @@ metadata:
   annotations:
     prometheus.io/prombench.exit_on_error: 'true'
     prometheus.io/prombench.wait_on_update: 'true'
-    prometheus.io/prombench.retry_count: '60'
+    prometheus.io/prombench.retry_count: '90'
 spec:
   replicas: 1
   selector:

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -43,6 +43,7 @@ spec:
         imagePullPolicy: Always
         args:
         # - Create /tmp/READY to marmake k the StatefulSet as ready once make deploy succeeds
+        # - /tmp/READY is used in readiness probe
         # - Sleep forever after make deploy succeededs.
         - "make deploy && touch /tmp/READY && echo 'deploy succeeded, now sleeping' && while sleep 86400; do :; done"
         env:
@@ -71,6 +72,7 @@ spec:
               - "/bin/sh"
               - "-c"
               # - Delete /tmp/READY to mark the StatefulSet as un-ready before cleanup
+              # - /tmp/READY is used in readiness probe
               # - Sleep until all_nodepools_running returns a success code
               # - Then run make clean and kill the container.
               - "rm /tmp/READY && until make all_nodepools_running; do echo waiting for nodepools to be created; sleep 10; done; make clean; kill -9 -1"

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -5,8 +5,6 @@ metadata:
   labels:
     app: prombench-test-{{ .PR_NUMBER }}
   annotations:
-    prometheus.io/prombench.exit_on_error: 'true'
-    prometheus.io/prombench.wait_on_update: 'true'
     prometheus.io/prombench.retry_count: '90'
 spec:
   replicas: 1

--- a/tools/commentMonitor/README.md
+++ b/tools/commentMonitor/README.md
@@ -7,7 +7,7 @@ comments and set labels on the pr from which the comment was received.
 See [the github issue events api](https://developer.github.com/v3/issues/events/) for some examples.
 
 #### Environment Variables:
-- `COMMENT_TEMPLATE`: If set, will post a comment with the content. It uses the Golang template variables substitutions. If content text includes a variable name `{{ index .envVariable }}` that exists as an env variable it is expanded with the content of the variable.
+- `COMMENT_TEMPLATE`: If set, will post a comment with the content. It uses the Golang template variables substitutions. If content text includes a variable name `{{ index . "SOME_VAR" }}` that exists as an env variable or comment argument it is expanded with the content of the variable.
 - `LABEL_NAME`: If set, will add the label to the PR.
 - `GITHUB_TOKEN` : GitHub oauth token used for posting comments and settings the label.
 


### PR DESCRIPTION
This PR attempts to add custom wait for complete deployment of a prombench test, so that github action waits till the error or completion in deploying a statefulset.

Todo:
- [x] ~Custom annotation: retry count~ (6xGlobalRetryCount for statefulSet)
- [x] ~Custom annotation: exit on error~(Made default behavior)
- [x] ~Custom annotation: wait on update~(Made default behaviour)
- [x] add readiness probe