### PR TITLE
[WIP] [prombench] Log on existing nodepool and no error on service re-apply/update

### DIFF
--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -322,7 +322,10 @@ func (c *GKE) NodePoolCreate(*kingpin.ParseContext) error {
 				})
 
 			if err != nil {
-				log.Fatalf("Couldn't create cluster nodepool '%v', file:%v ,err: %v", node.Name, deployment.FileName, err)
+				if st, ok := status.FromError(err); ok && st.Code() != codes.AlreadyExists {
+					log.Fatalf("Couldn't create cluster nodepool '%v', file:%v ,err: %v", node.Name, deployment.FileName, err)
+				}
+				log.Printf("nodepool already exists '%v', file:%v ,err: %v", node.Name, deployment.FileName, err)
 			}
 
 			err = provider.RetryUntilTrue(

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -771,12 +771,19 @@ func (c *K8s) serviceApply(resource runtime.Object) error {
 		for _, l := range list.Items {
 			if l.Name == req.Name {
 				exists = true
+				if req.ResourceVersion == "" {
+					req.ResourceVersion = l.ResourceVersion
+				}
+				if req.Spec.ClusterIP == "" {
+					req.Spec.ClusterIP = l.Spec.ClusterIP
+				}
 				break
 			}
 		}
 
 		if exists {
 			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+
 				_, err := client.Update(req)
 				return err
 			}); err != nil {

--- a/prombench/cmd/prombench/Dockerfile
+++ b/prombench/cmd/prombench/Dockerfile
@@ -7,11 +7,11 @@ RUN apk add --update make git
 ENV TEST_INFRA_DIR /test-infra
 ENV TEST_INFRA_REPO https://github.com/prometheus/prombench.git
 
-ENV PROMBENCH_DIR $TEST_INFRA_DIR/prombench
+ENV PROMBENCH_DIR /prombench
 
 COPY prombench /usr/bin/prombench
 COPY cmd/prombench/clone.sh /usr/bin/clone.sh
 
 ENTRYPOINT ["/usr/bin/clone.sh"]
 
-WORKDIR $TEST_INFRA_DIR
+WORKDIR $PROMBENCH_DIR

--- a/prombench/cmd/prombench/Dockerfile
+++ b/prombench/cmd/prombench/Dockerfile
@@ -2,7 +2,7 @@
 FROM golang:1.12-alpine
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-RUN apk add --update make git
+RUN apk add --update --no-cache make git tini
 
 ENV TEST_INFRA_DIR /test-infra
 ENV TEST_INFRA_REPO https://github.com/prometheus/prombench.git
@@ -12,6 +12,6 @@ ENV PROMBENCH_DIR /prombench
 COPY prombench /usr/bin/prombench
 COPY cmd/prombench/clone.sh /usr/bin/clone.sh
 
-ENTRYPOINT ["/usr/bin/clone.sh"]
+ENTRYPOINT ["/sbin/tini", "--", "/usr/bin/clone.sh"]
 
 WORKDIR $PROMBENCH_DIR

--- a/prombench/cmd/prombench/Dockerfile
+++ b/prombench/cmd/prombench/Dockerfile
@@ -13,3 +13,5 @@ COPY prombench /usr/bin/prombench
 COPY cmd/prombench/clone.sh /usr/bin/clone.sh
 
 ENTRYPOINT ["/usr/bin/clone.sh"]
+
+WORKDIR $TEST_INFRA_DIR

--- a/prombench/cmd/prombench/clone.sh
+++ b/prombench/cmd/prombench/clone.sh
@@ -3,10 +3,11 @@
 # clone the test-infra repo for latest Makefile and manifest files
 git clone $TEST_INFRA_REPO $TEST_INFRA_DIR
 
+# copy prombench files to $PROMBENCH_DIR
+cp -r $TEST_INFRA_DIR/prombench/* $PROMBENCH_DIR/
 # copy the prombench binary to the cloned directory
 cp /usr/bin/prombench $PROMBENCH_DIR/
 
-cd $PROMBENCH_DIR
 # execute arguments passed to the image
 # eval is needed so that bash keywords are not run as commands
 eval "$@"

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -75,7 +75,7 @@ spec:
               # - /tmp/READY is used in readiness probe
               # - Sleep until all_nodepools_running returns a success code
               # - Then run make clean and kill the container.
-              - "rm /tmp/READY ; cd prombench && until make all_nodepools_running; do echo waiting for nodepools to be created; sleep 10; done; make clean; kill -9 -1"
+              - "rm /tmp/READY; until make all_nodepools_running; do echo waiting for nodepools to be created; sleep 10; done; make clean; kill -9 -1"
         readinessProbe:
           exec:
             command:

--- a/prombench/manifests/prombench/stateful-set.yaml
+++ b/prombench/manifests/prombench/stateful-set.yaml
@@ -75,7 +75,7 @@ spec:
               # - /tmp/READY is used in readiness probe
               # - Sleep until all_nodepools_running returns a success code
               # - Then run make clean and kill the container.
-              - "rm /tmp/READY && until make all_nodepools_running; do echo waiting for nodepools to be created; sleep 10; done; make clean; kill -9 -1"
+              - "rm /tmp/READY ; cd prombench && until make all_nodepools_running; do echo waiting for nodepools to be created; sleep 10; done; make clean; kill -9 -1"
         readinessProbe:
           exec:
             command:


### PR DESCRIPTION
Closes #44 

and we need to just log it if nodepool already exists, otherwise if there's an error when applying prombench components this does into a crash loop because `make deploy` is run and it errors out `nodepool already exits` which is not a problem when trying to recover from a crash.

this is different from benchmark restarts where the initContainer is run again too, but in this case just the main container crashes (if there's an error in deploying) and when it tries to redeploy it finds that there's an existing nodepool and crashes again. 

this PR fixes it, now there will be attempts to redeploy components after they fail automatically. and once there is a timeout in github actions. we'll see the fail comment on the PR.

also updated the `WORKDIR` because `make clean` was running from another directory since we didn't have a `WORKDIR` set.

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>