### PR TITLE
[WIP] prometheus-builder only builds prometheus binary

### DIFF
--- a/prombench/temp/prometheus-builder/build.sh
+++ b/prombench/temp/prometheus-builder/build.sh
@@ -24,7 +24,7 @@ fi
 git checkout pr-branch
 
 echo ">> Creating prometheus binaries"
-if ! make build; then
+if ! promu build prometheus; then
     echo "ERROR:: Building of binaries failed"
     exit 1;
 fi


### PR DESCRIPTION
We don't need to build promtool . This saves some time. 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>