### PR TITLE
Build prometheus only for prometheus builder

### DIFF
--- a/prombench/temp/prometheus-builder/build.sh
+++ b/prombench/temp/prometheus-builder/build.sh
@@ -24,7 +24,7 @@ fi
 git checkout pr-branch
 
 echo ">> Creating prometheus binaries"
-if ! make build; then
+if ! make build PROMU_BINARIES="prometheus"; then
     echo "ERROR:: Building of binaries failed"
     exit 1;
 fi


### PR DESCRIPTION
Note: This will build both prometheus and promtool on commits before https://github.com/prometheus/prometheus/pull/5966

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>