### PR TITLE
revert make clean target order to older state and log fatal on AllNodepools* functions

### DIFF
--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -465,10 +465,10 @@ func (c *GKE) AllNodepoolsRunning(*kingpin.ParseContext) error {
 		for _, node := range reqC.Cluster.NodePools {
 			isRunning, err := c.nodePoolRunning(reqC.Zone, reqC.ProjectId, reqC.Cluster.Name, node.Name)
 			if err != nil {
-				return errors.New("error fetching nodePool info")
+				log.Fatalf("error fetching nodePool info")
 			}
 			if !isRunning {
-				return errors.Errorf("nodepool not running name: %v", node.Name)
+				log.Fatalf("nodepool not running name: %v", node.Name)
 			}
 		}
 	}
@@ -488,10 +488,10 @@ func (c *GKE) AllNodepoolsDeleted(*kingpin.ParseContext) error {
 		for _, node := range reqC.Cluster.NodePools {
 			isRunning, err := c.nodePoolRunning(reqC.Zone, reqC.ProjectId, reqC.Cluster.Name, node.Name)
 			if err != nil {
-				return errors.New("error fetching nodePool info")
+				log.Fatalf("error fetching nodePool info")
 			}
 			if isRunning {
-				return errors.Errorf("nodepool running name: %v", node.Name)
+				log.Fatalf("nodepool running name: %v", node.Name)
 			}
 		}
 	}

--- a/prombench/Makefile
+++ b/prombench/Makefile
@@ -6,6 +6,8 @@ endif
 
 .PHONY: deploy clean
 deploy: nodepool_create resource_apply
+# GCP sometimes takes longer than 30 tries when trying to delete nodepools
+# if k8s resources are not already cleared
 clean: resource_delete nodepool_delete
 
 create_test_ss:

--- a/prombench/Makefile
+++ b/prombench/Makefile
@@ -6,7 +6,7 @@ endif
 
 .PHONY: deploy clean
 deploy: nodepool_create resource_apply
-clean: nodepool_delete resource_delete
+clean: resource_delete nodepool_delete
 
 create_test_ss:
 	$(PROMBENCH_CMD) gke resource apply -a ${AUTH_FILE} -v PROJECT_ID:${PROJECT_ID} \


### PR DESCRIPTION
This PR adds two changes: 

1) GCP sometimes takes longer than 30 tries when trying to delete the nodepools if resources are not cleared or if resources are getting added/modified in that nodepool.

Clearing the resources first and then deleting the nodepool seems like the way to go.


2) Log fatal instead of returning error in `AllNodepoolsRunning` and `AllNodepoolsDeleted` because otherwise prombench prints the usage info with each check if they return error.

https://github.com/prometheus/prombench/blob/a2a6290e2e45acdf89fd9f386a225d849f1be5f2/prombench/cmd/prombench/prombench.go#L77-L81

cc @krasi-georgiev 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>