### PR TITLE
[DO NOT MERGE] Added container resources limits to fake-webserver Deployment

### DIFF
--- a/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
+++ b/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
@@ -27,7 +27,7 @@ data:
             requests:
               memory: 80Mi
             limits:
-              memory: 7600Mi
+              memory: 99999Mi
             ports:
             - name: metrics1
               containerPort: 8080
@@ -65,7 +65,9 @@ spec:
         requests:
           memory: 80Mi
         limits:
-          memory: 7600Mi
+          # K8s bug, for some reason fake-webserver can't cross 2GiB memory
+          # So we set to some higher value.
+          memory: 99999Mi
         ports:
         - name: metrics1
           containerPort: 8080

--- a/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
+++ b/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
@@ -24,6 +24,10 @@ data:
           containers:
           - name: fake-webserver
             image: docker.io/prombench/fake-webserver:2.0.0
+            requests:
+              memory: 80Mi
+            limits:
+              memory: 7600Mi
             ports:
             - name: metrics1
               containerPort: 8080
@@ -58,6 +62,10 @@ spec:
       containers:
       - name: fake-webserver
         image: docker.io/prombench/fake-webserver:2.0.0
+        requests:
+          memory: 80Mi
+        limits:
+          memory: 7600Mi
         ports:
         - name: metrics1
           containerPort: 8080


### PR DESCRIPTION
After upgrading to 1.13.x in GKE, fake-webserver fails to scale up because k8s puts some limits on memory usage. So we explicitly set limits for fake-webserver. The problem persists in 1.14.x too.

After adding these resource limits and requests, prombench tests run as expected.

See #286 
See https://github.com/kubernetes/kubernetes/issues/73572

The set limit is arbitrary, had to set something above 2GiB but was unsure how much fake-webserver consumes.

more on differences in limits and requests for resources:
https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#how-pods-with-resource-limits-are-run

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>