### PR TITLE
Increase GlobalRetryCount for prombench

### DIFF
--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	GlobalRetryCount = 30
+	GlobalRetryCount = 50
 	Separator        = "---"
 	globalRetryTime  = 10 * time.Second
 )


### PR DESCRIPTION
Increase GlobalRetryCount to 50 from 30 for prombench. Sometimes deleting the nodepool takes longer than 30 tries, as prombench now exits on error the second nodepools deletion does not start.

50 tries should be enough to ensure that the nodepool got deleted.

While testing the new prombench setup GitHub action conveniently notified about this here: https://github.com/prometheus-community/prometheus/pull/18#issuecomment-532561056

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>