### PR TITLE
Update fakewebserver image to 2.0.1

### DIFF
--- a/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
+++ b/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
@@ -23,7 +23,7 @@ data:
         spec:
           containers:
           - name: fake-webserver
-            image: docker.io/prombench/fake-webserver:2.0.0
+            image: docker.io/prombench/fake-webserver:2.0.1
             ports:
             - name: metrics1
               containerPort: 8080
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
       - name: fake-webserver
-        image: docker.io/prombench/fake-webserver:2.0.0
+        image: docker.io/prombench/fake-webserver:2.0.1
         ports:
         - name: metrics1
           containerPort: 8080


### PR DESCRIPTION
There is no changes made to files inside `/tools/fake-webserver`, the new image just contains the binary built with `go 1.13`

After upgrading to k8s to 13.x in GKE, the node running `fake-webserver` keeps running out of memory. The new image (`2.0.1`) does not seem to be facing the issue.

**Old Image - `2.0.0`**
`fake-webserver` scaled to 20 replicas on `COS` NodeImage on K8s 13.x 
![20-scale](https://user-images.githubusercontent.com/12918431/66528257-d95eef80-eb1c-11e9-9687-6491104d7ad4.png)


**New Image - `2.0.1`**
`fake-webserver` scaled to 20 replicas on `COS` NodeImage on K8s 13.x 
![20scale](https://user-images.githubusercontent.com/12918431/66528290-f3003700-eb1c-11e9-9c5d-adeb2f6c8dae.png)


Profiles:
- `2.0.1` :  20 replicas running healthy 
[20scale-newimage.pb.gz](https://github.com/prometheus/prombench/files/3709858/20scale-newimage.pb.gz)
- `2.0.0` : 20 replicas running healthy
[20scale-oldimage-all-pods-healthy.pb.gz](https://github.com/prometheus/prombench/files/3709863/20scale-oldimage-all-pods-healthy.pb.gz)
- `2.0.0` : 20 replicas, some pods are evicted
[20scale-oldimage-somepods-evicted.pb.gz](https://github.com/prometheus/prombench/files/3709864/20scale-oldimage-somepods-evicted.pb.gz)


Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>