### PR TITLE
Upgraded prometheus-builder Dockerfile to use go1.13

### DIFF
--- a/prombench/temp/prometheus-builder/Dockerfile
+++ b/prombench/temp/prometheus-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12
+FROM golang:1.13
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
 RUN \


### PR DESCRIPTION
Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>