### PR TITLE
replace AUTH_FILE GitHub Secret with PROMBENCH_GKE_AUTH

### DIFF
--- a/prombench/README.md
+++ b/prombench/README.md
@@ -72,7 +72,7 @@ export GITHUB_REPO=prometheus
 Place a workflow file in the `.github` directory of the repository.
 See the [prometheus/prometheus](https://github.com/prometheus/prometheus) repository for an example.
 
-Create a github action `AUTH_FILE` secret with the base64 encoded content of the `service-account.json` file.
+Create a github action `PROMBENCH_GKE_AUTH` secret with the base64 encoded content of the `service-account.json` file.
 ```
 cat $AUTH_FILE | base64 -w 0
 ```


### PR DESCRIPTION
Updated readme about change of  `AUTH_FILE` GitHub Secret to `PROMBENCH_GKE_AUTH`

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>