### PR TITLE
[WIP] Added circle-ci artifacts to prometheus-builder

### DIFF
--- a/prombench/Makefile
+++ b/prombench/Makefile
@@ -20,6 +20,7 @@ resource_apply:
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:${CLUSTER_NAME} \
 		-v PR_NUMBER:${PR_NUMBER} -v RELEASE:${RELEASE} -v DOMAIN_NAME:${DOMAIN_NAME} \
 		-v GITHUB_ORG:${GITHUB_ORG} -v GITHUB_REPO:${GITHUB_REPO} \
+		-v LAST_COMMIT_SHA:${LAST_COMMIT_SHA} \
 		-f manifests/prombench/benchmark
 
 # NOTE: required because namespace and cluster-role are not part of the created nodepools

--- a/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
@@ -34,7 +34,7 @@ spec:
         runAsUser: 0
       initContainers:
       - name: prometheus-builder
-        image: docker.io/prombench/prometheus-builder:2.0.2
+        image: docker.io/prombench/prometheus-builder:2.0.3
         env:
         - name: PR_NUMBER
           value: "{{ .PR_NUMBER }}"
@@ -44,6 +44,8 @@ spec:
           value: "{{ .GITHUB_ORG }}"
         - name: GITHUB_REPO
           value: "{{ .GITHUB_REPO }}"
+        - name: LAST_COMMIT_SHA
+          value: "{{ .LAST_COMMIT_SHA }}"
         volumeMounts:
         - name: prometheus-executable
           mountPath: /prometheus-builder

--- a/prombench/temp/prometheus-builder/Dockerfile
+++ b/prombench/temp/prometheus-builder/Dockerfile
@@ -1,12 +1,19 @@
-FROM alpine:3.10.3
+FROM golang:1.13
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-RUN apk update && apk add --no-cache \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apt-utils \
+    build-essential \
     ca-certificates \
+    make \
     git \
     jq \
-    bash \
-    curl
+    curl \
+    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs yarn \
+    && rm -rf /var/lib/apt/lists/*
 
 COPY build.sh /
 RUN chmod +x /build.sh

--- a/prombench/temp/prometheus-builder/Dockerfile
+++ b/prombench/temp/prometheus-builder/Dockerfile
@@ -1,21 +1,14 @@
-FROM golang:1.13
+FROM alpine:3.10.3
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-RUN \
-    apt-get update && apt-get install -y --no-install-recommends \
-        apt-utils \
-        build-essential \
-        ca-certificates \
-        make \
-        git \
-    && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends nodejs yarn \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk add --no-cache \
+    ca-certificates \
+    git \
+    jq \
+    bash \
+    curl
 
-RUN mkdir -p /go/src/github.com
-COPY build.sh /go/src/github.com/build.sh
-RUN chmod +x /go/src/github.com/build.sh
+COPY build.sh /
+RUN chmod +x /build.sh
 
-ENTRYPOINT ["/go/src/github.com/build.sh"]
+ENTRYPOINT ["/build.sh"]

--- a/prombench/temp/prometheus-builder/README.md
+++ b/prombench/temp/prometheus-builder/README.md
@@ -1,10 +1,16 @@
 ### Prometheus-Builder
 
-This is used for building prometheus binaries from Pull Requests and running them on containers.  
+This is used for building prometheus binaries from Pull Requests and running them on containers.
 Prombench uses this to build binaries for the Pull Request being benchmarked.
+
+### Running the docker image locally
+```
+docker run --rm -v $(pwd)/somedir:/prom -e VOLUME_DIR=/prom -e GITHUB_ORG=prometheus -e GITHUB_REPO=prometheus -e PR_NUMBER
+=<pr_no> -e LAST_COMMIT_SHA=<last_sha_from_pr> docker.io/prombench/prometheus-builder:2.0.3
+```
 
 ### Example for building the docker image
 From the repository root:
 ```
-$ make docker DOCKERFILE_PATH=prombench/temp/prometheus-builder/Dockerfile DOCKERBUILD_CONTEXT=prombench/temp/prometheus-builder DOCKER_IMAGE_NAME=prometheus-builder DOCKER_IMAGE_TAG=2.0.2
+$ make docker DOCKERFILE_PATH=prombench/temp/prometheus-builder/Dockerfile DOCKERBUILD_CONTEXT=prombench/temp/prometheus-builder DOCKER_IMAGE_NAME=prometheus-builder DOCKER_IMAGE_TAG=2.0.3
 ```

--- a/prombench/temp/prometheus-builder/build.sh
+++ b/prombench/temp/prometheus-builder/build.sh
@@ -1,12 +1,20 @@
 #!/bin/bash
 
-DIR="/go/src/github.com/prometheus/prometheus"
+CIRCLECI_BASE_API_URL="https://circleci.com/api/v1.1/project/github"
+FILTER="successful"
+CIRCLE_JOB="build"
+OS="linux"
+ARCH="amd64"
 
-if [[ -z $PR_NUMBER || -z $VOLUME_DIR || -z $GITHUB_ORG || -z $GITHUB_REPO ]]; then
+DIR="/tmp/prometheus"
+rm -rf $DIR
+
+if [[ -z $PR_NUMBER || -z $VOLUME_DIR || -z $GITHUB_ORG || -z $GITHUB_REPO || -z $LAST_COMMIT_SHA ]]; then
     echo "ERROR:: environment variables not set correctly"
     exit 1;
 fi
 
+# Clone git repo
 echo ">> Cloning repository $GITHUB_ORG/$GITHUB_REPO"
 if ! git clone https://github.com/$GITHUB_ORG/$GITHUB_REPO.git $DIR; then
     echo "ERROR:: Cloning of repo $GITHUB_ORG/$GITHUB_REPO failed"
@@ -15,20 +23,40 @@ fi
 
 cd $DIR || exit 1
 
+# Checkout PR
 echo ">> Fetching Pull Request $GITHUB_ORG/$GITHUB_REPO/pull/$PR_NUMBER"
 if ! git fetch origin pull/$PR_NUMBER/head:pr-branch; then
     echo "ERROR:: Fetching of PR $PR_NUMBER failed"
     exit 1;
 fi
-
 git checkout pr-branch
 
-echo ">> Creating prometheus binaries"
-if ! make build PROMU_BINARIES="prometheus"; then
-    echo "ERROR:: Building of binaries failed"
+# jq command to get the build.
+JQ_ARG='[.[] | select(.build_parameters.CIRCLE_JOB==$JOB)][0] | {build_id: .build_num, v_rev: .vcs_revision}'
+
+# Builds are returned in the order that they were created.
+URL="$CIRCLECI_BASE_API_URL/$GITHUB_ORG/$GITHUB_REPO/tree/pull/$PR_NUMBER?filter=$FILTER"
+BUILD=$(curl -s "$URL" | jq --arg JOB $CIRCLE_JOB "$JQ_ARG")
+BUILD_ID=$(echo $BUILD | jq -r '.build_id' )
+BUILD_REV=$(echo $BUILD | jq -r '.v_rev' )
+
+# Check if the build is of the latest commit.
+if [ $LAST_COMMIT_SHA != $BUILD_REV ]; then
+    echo "Last commit hash and the commit hash of the circleci build don't match. exiting"
     exit 1;
 fi
 
+# Get the artifact url.
+JQ_ARG='.[] | select(.path==$PATH) | .url'
+URL="$CIRCLECI_BASE_API_URL/$GITHUB_ORG/$GITHUB_REPO/$BUILD_ID/artifacts"
+PROMETHEUS_BIN_URL=$(curl -s "$URL" | jq -r --arg PATH "build/$OS-$ARCH/prometheus" "$JQ_ARG")
+
+# Download the artifact.
+echo "Downloading artifact: $PROMETHEUS_BIN_URL"
+curl -O "$PROMETHEUS_BIN_URL"
+chmod u+x prometheus
+
+# Copy files to mounted volume.
 echo ">> Copy files to volume"
 cp prometheus               $VOLUME_DIR/prometheus
 cp -r console_libraries/    $VOLUME_DIR


### PR DESCRIPTION
Closes #83 
Closes #163 

With this PR, `prometheus-builder` no longer builds prometheus, instead it downloads the artifact for that PR and uses that to copy it to the mounted volume.

`prometheus-builder` will no longer be needed to be updated any dependency change once this gets merged.

This is working locally, yet to test this on the cluster. 

Another issue I faced was that, circle-ci api endpoint is not working as expected in few cases:
- https://circleci.com/api/v1.1/project/github/prometheus/prometheus/tree/pull/6326?filter=successful
- https://circleci.com/api/v1.1/project/github/prometheus/prometheus/tree/pull/6325?filter=successful

For example, api works as expected with https://github.com/prometheus/prometheus/pull/6325 but not with https://github.com/prometheus/prometheus/pull/6326

cc @krasi-georgiev @simonpasquier 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>