### PR TITLE
Run funcbench via GKE

### DIFF
--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -81,7 +81,7 @@ func (b *Benchmarker) execBenchmark(pkgRoot string, commit plumbing.Hash) (out s
 	// TODO(bwplotka): Allow memprofiles.
 	extraArgs := []string{"-benchtime", b.benchTime.String()}
 	extraArgs = append(extraArgs, "-timeout", b.benchTimeout.String())
-	benchCmd := []string{"bash", "-c", strings.Join(append(append([]string{"cd", pkgRoot, "&&", "go", "test", "-run", "^$", "-bench", fmt.Sprintf("^%s$", b.benchFunc), "-benchmem"}, extraArgs...), "./..."), " ")}
+	benchCmd := []string{"sh", "-c", strings.Join(append(append([]string{"cd", pkgRoot, "&&", "go", "test", "-run", "^$", "-bench", fmt.Sprintf("^%s$", b.benchFunc), "-benchmem"}, extraArgs...), "./..."), " ")}
 
 	b.logger.Println("Executing benchmark cmd:", benchCmd)
 	out, err = b.c.exec(benchCmd...)

--- a/funcbench/env.go
+++ b/funcbench/env.go
@@ -103,10 +103,6 @@ func newGitHubEnv(ctx context.Context, e environment, owner, repo string, prNumb
 		e.home = "."
 	}
 
-	if err := os.Chdir(e.home); err != nil {
-		return nil, err
-	}
-
 	ghClient := newGitHubClient(owner, repo, prNumber)
 	r, err := git.PlainCloneContext(ctx, fmt.Sprintf("%s/%s", e.home, ghClient.repo), false, &git.CloneOptions{
 		URL:      fmt.Sprintf("https://github.com/%s/%s.git", ghClient.owner, ghClient.repo),
@@ -115,11 +111,11 @@ func newGitHubEnv(ctx context.Context, e environment, owner, repo string, prNumb
 	})
 	if err != nil {
 		// If repo already exists, git.ErrRepositoryAlreadyExists will be returned.
-		return nil, errors.Wrap(err, "git clone")
+		return nil, err
 	}
 
-	if err := os.Chdir(filepath.Join(os.Getenv("GITHUB_WORKSPACE"), ghClient.repo)); err != nil {
-		return nil, errors.Wrapf(err, "changing to GITHUB_WORKSPACE/%s dir", ghClient.repo)
+	if err := os.Chdir(filepath.Join(e.home, ghClient.repo)); err != nil {
+		return nil, err
 	}
 
 	g := &GitHub{

--- a/funcbench/main.go
+++ b/funcbench/main.go
@@ -160,7 +160,7 @@ func funcbench(
 		return errors.Wrap(err, "get head")
 	}
 
-	if _, err := bench.c.exec("bash", "-c", "git update-index -q --ignore-submodules --refresh && git diff-files --quiet --ignore-submodules --"); err != nil {
+	if _, err := bench.c.exec("sh", "-c", "git update-index -q --ignore-submodules --refresh && git diff-files --quiet --ignore-submodules --"); err != nil {
 		return errors.Wrap(err, "not clean worktree")
 	}
 

--- a/funcbench/manifests/benchmark/1_namespace.yaml
+++ b/funcbench/manifests/benchmark/1_namespace.yaml
@@ -1,0 +1,5 @@
+#A new namespace is created to differentiate the instances of funcbench
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: funcbench-{{ .PR_NUMBER }}

--- a/funcbench/manifests/benchmark/2_deployment.yaml
+++ b/funcbench/manifests/benchmark/2_deployment.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: workflow
+  namespace: funcbench-{{ .PR_NUMBER }}
+data:
+  event.json: |
+    {
+      "action": "created",
+      "issue": {
+        "number": {{ .PR_NUMBER }}
+      },
+      "repository": {
+        "name": "{{ .GITHUB_REPO }}",
+        "owner": {
+          "login": "{{ .GITHUB_ORG }}"
+        }
+      }
+    }
+  BRANCH: {{ .BRANCH }}
+  RACE: {{ .RACE }}
+  REGEX: {{ .REGEX }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: funcbench-test-{{ .PR_NUMBER }}
+  namespace: funcbench-{{ .PR_NUMBER }}
+  labels:
+    app: prometheus
+    funcbench: test-{{ .PR_NUMBER }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: prometheus
+      funcbench: test-{{ .PR_NUMBER }}
+  template:
+    metadata:
+      namespace: funcbench-{{ .PR_NUMBER }}
+      labels:
+        app: prometheus
+        funcbench: test-{{ .PR_NUMBER }}
+    spec:
+      initContainers:
+      - name: clean-up
+        image: busybox:latest
+        command: ['sh', '-c', 'rm -fr /build/* && mkdir /build/tmp && mkdir /build/src']
+        volumeMounts:
+        - name: instance-ssd
+          mountPath: /build
+      containers:
+      - name: funcbench
+        image: nevill/funcbench:latest
+        imagePullPolicy: Always
+        env:
+          - name: GITHUB_WORKSPACE
+            value: /build/src
+          - name: GITHUB_TOKEN
+            value: {{ .GITHUB_TOKEN }}
+          - name: GITHUB_SHA
+            value: {{ .LAST_COMMIT_SHA }}
+          - name: GOTMPDIR
+            value: /build/tmp
+          - name: TMPDIR
+            value: /build/tmp
+        volumeMounts:
+        - name: event-json
+          mountPath: /github/workflow
+        - name: comment-monitor
+          mountPath: /github/home/commentMonitor
+        - name: instance-ssd
+          mountPath: /build
+      volumes:
+      - name: comment-monitor
+        configMap:
+          name: workflow
+      - name: event-json
+        configMap:
+          name: workflow
+      - name: instance-ssd
+        hostPath:
+          # /mnt is where GKE keeps it's SSD
+          # don't change this if you want Prometheus to take advantage of these local SSDs
+          path: /mnt/disks/ssd0
+      nodeSelector:
+        cloud.google.com/gke-nodepool: funcbench-{{ .PR_NUMBER }}
+        isolation: prometheus

--- a/funcbench/manifests/benchmark/2_job.yaml
+++ b/funcbench/manifests/benchmark/2_job.yaml
@@ -30,6 +30,8 @@ metadata:
     app: prometheus
     funcbench: test-{{ .PR_NUMBER }}
 spec:
+  # never re-create a new pod
+  backoffLimit: 0
   template:
     metadata:
       namespace: funcbench-{{ .PR_NUMBER }}

--- a/funcbench/manifests/benchmark/2_job.yaml
+++ b/funcbench/manifests/benchmark/2_job.yaml
@@ -21,8 +21,8 @@ data:
   RACE: {{ .RACE }}
   REGEX: {{ .REGEX }}
 ---
-apiVersion: apps/v1
-kind: Deployment
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: funcbench-test-{{ .PR_NUMBER }}
   namespace: funcbench-{{ .PR_NUMBER }}
@@ -30,11 +30,6 @@ metadata:
     app: prometheus
     funcbench: test-{{ .PR_NUMBER }}
 spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: prometheus
-      funcbench: test-{{ .PR_NUMBER }}
   template:
     metadata:
       namespace: funcbench-{{ .PR_NUMBER }}
@@ -42,6 +37,7 @@ spec:
         app: prometheus
         funcbench: test-{{ .PR_NUMBER }}
     spec:
+      restartPolicy: Never
       initContainers:
       - name: clean-up
         image: busybox:latest

--- a/funcbench/manifests/benchmark/2_job.yaml
+++ b/funcbench/manifests/benchmark/2_job.yaml
@@ -26,18 +26,10 @@ kind: Job
 metadata:
   name: funcbench-test-{{ .PR_NUMBER }}
   namespace: funcbench-{{ .PR_NUMBER }}
-  labels:
-    app: prometheus
-    funcbench: test-{{ .PR_NUMBER }}
 spec:
   # never re-create a new pod
   backoffLimit: 0
   template:
-    metadata:
-      namespace: funcbench-{{ .PR_NUMBER }}
-      labels:
-        app: prometheus
-        funcbench: test-{{ .PR_NUMBER }}
     spec:
       restartPolicy: Never
       initContainers:

--- a/funcbench/manifests/benchmark/2_job.yaml
+++ b/funcbench/manifests/benchmark/2_job.yaml
@@ -1,26 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: workflow
-  namespace: funcbench-{{ .PR_NUMBER }}
-data:
-  event.json: |
-    {
-      "action": "created",
-      "issue": {
-        "number": {{ .PR_NUMBER }}
-      },
-      "repository": {
-        "name": "{{ .GITHUB_REPO }}",
-        "owner": {
-          "login": "{{ .GITHUB_ORG }}"
-        }
-      }
-    }
-  BRANCH: {{ .BRANCH }}
-  RACE: {{ .RACE }}
-  REGEX: {{ .REGEX }}
----
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -43,31 +20,26 @@ spec:
       - name: funcbench
         image: nevill/funcbench:latest
         imagePullPolicy: Always
+        args:
+          - "-o"
+          - "{{ .GITHUB_ORG }}"
+          - "-r"
+          - "{{ .GITHUB_REPO }}"
+          - "-p"
+          - "{{ .PR_NUMBER }}"
+          - "{{ .BRANCH }}"
+          - "{{ .REGEX }}"
         env:
           - name: GITHUB_WORKSPACE
             value: /build/src
           - name: GITHUB_TOKEN
-            value: {{ .GITHUB_TOKEN }}
+            value: "{{ .GITHUB_TOKEN }}"
           - name: GITHUB_SHA
-            value: {{ .LAST_COMMIT_SHA }}
-          - name: GOTMPDIR
-            value: /build/tmp
-          - name: TMPDIR
-            value: /build/tmp
+            value: "{{ .LAST_COMMIT_SHA }}"
         volumeMounts:
-        - name: event-json
-          mountPath: /github/workflow
-        - name: comment-monitor
-          mountPath: /github/home/commentMonitor
         - name: instance-ssd
           mountPath: /build
       volumes:
-      - name: comment-monitor
-        configMap:
-          name: workflow
-      - name: event-json
-        configMap:
-          name: workflow
       - name: instance-ssd
         hostPath:
           # /mnt is where GKE keeps it's SSD

--- a/funcbench/manifests/benchmark/2_job.yaml
+++ b/funcbench/manifests/benchmark/2_job.yaml
@@ -9,42 +9,27 @@ spec:
   template:
     spec:
       restartPolicy: Never
-      initContainers:
-      - name: clean-up
-        image: busybox:latest
-        command: ['sh', '-c', 'rm -fr /build/* && mkdir /build/tmp && mkdir /build/src']
-        volumeMounts:
-        - name: instance-ssd
-          mountPath: /build
       containers:
       - name: funcbench
-        image: nevill/funcbench:latest
+        image: nevill/funcbench:20200324
         imagePullPolicy: Always
         args:
+          - "-v"
           - "-o"
           - "{{ .GITHUB_ORG }}"
           - "-r"
           - "{{ .GITHUB_REPO }}"
           - "-p"
           - "{{ .PR_NUMBER }}"
+          - "-w"
+          - "/build"
           - "{{ .BRANCH }}"
           - "{{ .REGEX }}"
         env:
-          - name: GITHUB_WORKSPACE
-            value: /build/src
           - name: GITHUB_TOKEN
             value: "{{ .GITHUB_TOKEN }}"
           - name: GITHUB_SHA
             value: "{{ .LAST_COMMIT_SHA }}"
-        volumeMounts:
-        - name: instance-ssd
-          mountPath: /build
-      volumes:
-      - name: instance-ssd
-        hostPath:
-          # /mnt is where GKE keeps it's SSD
-          # don't change this if you want Prometheus to take advantage of these local SSDs
-          path: /mnt/disks/ssd0
       nodeSelector:
         cloud.google.com/gke-nodepool: funcbench-{{ .PR_NUMBER }}
         isolation: prometheus

--- a/funcbench/manifests/nodepools.yaml
+++ b/funcbench/manifests/nodepools.yaml
@@ -1,0 +1,15 @@
+zone: {{ .ZONE }}
+projectid: {{ .PROJECT_ID }}
+cluster:
+  name: {{ .CLUSTER_NAME }}
+  nodepools:
+  # These node-pools will be deployed on triggering benchmark
+  - name: funcbench-{{ .PR_NUMBER }}
+    initialnodecount: 1
+    config:
+      machinetype: n1-highmem-4
+      imagetype: COS
+      disksizegb: 20
+      localssdcount: 1
+      labels:
+        isolation: prometheus

--- a/funcbench/manifests/nodepools.yaml
+++ b/funcbench/manifests/nodepools.yaml
@@ -7,9 +7,9 @@ cluster:
   - name: funcbench-{{ .PR_NUMBER }}
     initialnodecount: 1
     config:
-      machinetype: n1-highmem-4
+      machinetype: n1-highmem-8
       imagetype: COS
-      disksizegb: 20
+      disksizegb: 50
       localssdcount: 1
       labels:
         isolation: prometheus

--- a/funcbench/manifests/nodepools.yaml
+++ b/funcbench/manifests/nodepools.yaml
@@ -9,7 +9,6 @@ cluster:
     config:
       machinetype: n1-highmem-8
       imagetype: COS
-      disksizegb: 50
-      localssdcount: 1
+      disksizegb: 100
       labels:
         isolation: prometheus

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -182,7 +182,8 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 				err = c.statefulSetApply(resource)
 			case "job":
 				err = c.jobApply(resource)
-				c.jobDelete(resource)
+				// Even job deletion fails, it will be removed together with nodepool.
+				_ = c.jobDelete(resource)
 			default:
 				err = fmt.Errorf("creating request for unimplimented resource type:%v", kind)
 			}

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -182,6 +182,7 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 				err = c.statefulSetApply(resource)
 			case "job":
 				err = c.jobApply(resource)
+				c.jobDelete(resource)
 			default:
 				err = fmt.Errorf("creating request for unimplimented resource type:%v", kind)
 			}
@@ -541,8 +542,8 @@ func (c *K8s) jobApply(resource runtime.Object) error {
 		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
 	}
 	return provider.RetryUntilTrue(
-		fmt.Sprintf("applying job:%v", req.Name),
-		provider.GlobalRetryCount,
+		fmt.Sprintf("running job:%v", req.Name),
+		5 * provider.GlobalRetryCount,
 		func() (bool, error) { return c.jobReady(resource) })
 }
 
@@ -1368,10 +1369,13 @@ func (c *K8s) jobReady(resource runtime.Object) (bool, error) {
 
 		// current jobReady only works for non-parallel jobs
 		// https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#parallel-jobs
-		succeeded := int32(1)
-		if res.Status.Succeeded == succeeded {
+		count := int32(1)
+		if res.Status.Succeeded == count {
 			return true, nil
+		} else if res.Status.Failed == count {
+			return true, errors.New(fmt.Sprintf("Job %v has failed", req.Name))
 		}
+
 		return false, nil
 	default:
 		return false, fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -182,7 +182,7 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 				err = c.statefulSetApply(resource)
 			case "job":
 				err = c.jobApply(resource)
-				// Even job deletion fails, it will be removed together with nodepool.
+				// Ignore the error as even when job deletion fails, it will be removed together with nodepool.
 				_ = c.jobDelete(resource)
 			default:
 				err = fmt.Errorf("creating request for unimplimented resource type:%v", kind)
@@ -1278,7 +1278,7 @@ func (c *K8s) serviceExists(resource runtime.Object) (bool, error) {
 			return false, errors.Wrapf(err, "Checking Service resource status failed")
 		}
 		if res.Spec.Type == apiCoreV1.ServiceTypeLoadBalancer {
-			// k8s API currently just supports LoadBalancerStatus
+			// K8s API currently just supports LoadBalancerStatus.
 			if len(res.Status.LoadBalancer.Ingress) > 0 {
 				log.Printf("\tService %s Details", req.Name)
 				for _, x := range res.Status.LoadBalancer.Ingress {
@@ -1369,7 +1369,7 @@ func (c *K8s) jobReady(resource runtime.Object) (bool, error) {
 			return false, errors.Wrapf(err, "Checking Job resource:'%v' status failed err:%v", req.Name, err)
 		}
 
-		// current jobReady only works for non-parallel jobs
+		// Current `jobReady` only works for non-parallel jobs.
 		// https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#parallel-jobs
 		count := int32(1)
 		if res.Status.Succeeded == count {

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -541,9 +541,10 @@ func (c *K8s) jobApply(resource runtime.Object) error {
 	default:
 		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
 	}
+	const Infinite int = 1<<31 - 1
 	return provider.RetryUntilTrue(
 		fmt.Sprintf("running job:%v", req.Name),
-		5 * provider.GlobalRetryCount,
+		Infinite,
 		func() (bool, error) { return c.jobReady(resource) })
 }
 

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
 	appsV1 "k8s.io/api/apps/v1"
+	batchV1 "k8s.io/api/batch/v1"
 	apiCoreV1 "k8s.io/api/core/v1"
 	apiExtensionsV1beta1 "k8s.io/api/extensions/v1beta1"
 	rbac "k8s.io/api/rbac/v1"
@@ -179,6 +180,8 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 				err = c.customResourceApply(resource)
 			case "statefulset":
 				err = c.statefulSetApply(resource)
+			case "job":
+				err = c.jobApply(resource)
 			default:
 				err = fmt.Errorf("creating request for unimplimented resource type:%v", kind)
 			}
@@ -228,6 +231,8 @@ func (c *K8s) ResourceDelete(deployments []Resource) error {
 				err = c.customResourceDelete(resource)
 			case "statefulset":
 				err = c.statefulSetDelete(resource)
+			case "job":
+				err = c.jobDelete(resource)
 			default:
 				err = fmt.Errorf("deleting request for unimplimented resource type:%v", kind)
 			}
@@ -465,7 +470,6 @@ func (c *K8s) statefulSetApply(resource runtime.Object) error {
 		if err != nil {
 			return errors.Wrapf(err, "error listing resource : %v, name: %v", kind, req.Name)
 		}
-
 		var exists bool
 		for _, l := range list.Items {
 			if l.Name == req.Name {
@@ -496,6 +500,50 @@ func (c *K8s) statefulSetApply(resource runtime.Object) error {
 		fmt.Sprintf("applying statefulSet:%v", req.Name),
 		provider.GlobalRetryCount,
 		func() (bool, error) { return c.statefulSetReady(resource) })
+}
+
+func (c *K8s) jobApply(resource runtime.Object) error {
+	req := resource.(*batchV1.Job)
+	kind := resource.GetObjectKind().GroupVersionKind().Kind
+	if len(req.Namespace) == 0 {
+		req.Namespace = "default"
+	}
+
+	switch v := resource.GetObjectKind().GroupVersionKind().Version; v {
+	case "v1":
+		client := c.clt.BatchV1().Jobs(req.Namespace)
+		list, err := client.List(apiMetaV1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "error listing resource : %v, name: %v", kind, req.Name)
+		}
+		var exists bool
+		for _, l := range list.Items {
+			if l.Name == req.Name {
+				exists = true
+				break
+			}
+		}
+
+		if exists {
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, err := client.Update(req)
+				return err
+			}); err != nil {
+				return errors.Wrapf(err, "resource update failed - kind: %v, name: %v", kind, req.Name)
+			}
+			log.Printf("resource updated - kind: %v, name: %v", kind, req.Name)
+			return nil
+		} else if _, err := client.Create(req); err != nil {
+			return errors.Wrapf(err, "resource creation failed - kind: %v, name: %v", kind, req.Name)
+		}
+		log.Printf("resource created - kind: %v, name: %v", kind, req.Name)
+	default:
+		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
+	}
+	return provider.RetryUntilTrue(
+		fmt.Sprintf("applying job:%v", req.Name),
+		provider.GlobalRetryCount,
+		func() (bool, error) { return c.jobReady(resource) })
 }
 
 func (c *K8s) customResourceApply(resource runtime.Object) error {
@@ -1003,6 +1051,27 @@ func (c *K8s) statefulSetDelete(resource runtime.Object) error {
 	return nil
 }
 
+func (c *K8s) jobDelete(resource runtime.Object) error {
+	req := resource.(*batchV1.Job)
+	kind := resource.GetObjectKind().GroupVersionKind().Kind
+	if len(req.Namespace) == 0 {
+		req.Namespace = "default"
+	}
+
+	switch v := resource.GetObjectKind().GroupVersionKind().Version; v {
+	case "v1":
+		client := c.clt.BatchV1().Jobs(req.Namespace)
+		delPolicy := apiMetaV1.DeletePropagationForeground
+		if err := client.Delete(req.Name, &apiMetaV1.DeleteOptions{PropagationPolicy: &delPolicy}); err != nil {
+			return errors.Wrapf(err, "resource delete failed - kind: %v, name: %v", kind, req.Name)
+		}
+		log.Printf("resource deleted - kind: %v , name: %v", kind, req.Name)
+	default:
+		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
+	}
+	return nil
+}
+
 func (c *K8s) customResourceDelete(resource runtime.Object) error {
 	req := resource.(*apiServerExtensionsV1beta1.CustomResourceDefinition)
 	kind := resource.GetObjectKind().GroupVersionKind().Kind
@@ -1273,6 +1342,34 @@ func (c *K8s) statefulSetReady(resource runtime.Object) (bool, error) {
 			replicas = *req.Spec.Replicas
 		}
 		if res.Status.ReadyReplicas == replicas {
+			return true, nil
+		}
+		return false, nil
+	default:
+		return false, fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
+	}
+}
+
+func (c *K8s) jobReady(resource runtime.Object) (bool, error) {
+	req := resource.(*batchV1.Job)
+	kind := resource.GetObjectKind().GroupVersionKind().Kind
+	if len(req.Namespace) == 0 {
+		req.Namespace = "default"
+	}
+
+	switch v := resource.GetObjectKind().GroupVersionKind().Version; v {
+	case "v1":
+		client := c.clt.BatchV1().Jobs(req.Namespace)
+
+		res, err := client.Get(req.Name, apiMetaV1.GetOptions{})
+		if err != nil {
+			return false, errors.Wrapf(err, "Checking Job resource:'%v' status failed err:%v", req.Name, err)
+		}
+
+		// current jobReady only works for non-parallel jobs
+		// https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/#parallel-jobs
+		succeeded := int32(1)
+		if res.Status.Succeeded == succeeded {
 			return true, nil
 		}
 		return false, nil


### PR DESCRIPTION
xref #310 

it includes:
- [x] Run `funcbench` as a Kubernetes Job
- [x] Drop param `-i event.json` from `funcbench` cli, add `org / repo / branch / prNumber / regex / raceEnabled / postComment` as input parameters
- [ ] Replace docker images `nevill/prombench`, `nevill/funcbench` once the latest are released
- [ ] Let `funcbench` run on Sole-tenant nodes

Once it's merge, we also have to update Github actions in main repository