### PR TITLE
Removed usage of DOCKERBUILD_CONTEXT variable.

### DIFF
--- a/prombench/temp/prometheus-builder/Dockerfile
+++ b/prombench/temp/prometheus-builder/Dockerfile
@@ -15,7 +15,7 @@ RUN \
     && rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /go/src/github.com
-COPY build.sh /go/src/github.com/build.sh
+COPY prombench/temp/prometheus-builder/build.sh /go/src/github.com/build.sh
 RUN chmod +x /go/src/github.com/build.sh
 
 ENTRYPOINT ["/go/src/github.com/build.sh"]

--- a/prombench/temp/prometheus-builder/README.md
+++ b/prombench/temp/prometheus-builder/README.md
@@ -6,5 +6,5 @@ Prombench uses this to build binaries for the Pull Request being benchmarked.
 ### Example for building the docker image
 From the repository root:
 ```
-$ make docker DOCKERFILE_PATH=prombench/temp/prometheus-builder/Dockerfile DOCKERBUILD_CONTEXT=prombench/temp/prometheus-builder DOCKER_IMAGE_NAME=prometheus-builder DOCKER_IMAGE_TAG=2.0.2
+$ make docker DOCKERFILE_PATH=prombench/temp/prometheus-builder/Dockerfile DOCKER_IMAGE_NAME=prometheus-builder DOCKER_IMAGE_TAG=2.0.2
 ```

--- a/tools/load-generator/Dockerfile
+++ b/tools/load-generator/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3
 COPY requirements.txt /usr/src/app/
 RUN pip install -r /usr/src/app/requirements.txt
 
-COPY main.py /usr/src/app/
+COPY tools/load-generator/*.py /usr/src/app/
 
 WORKDIR /usr/src/app
 

--- a/tools/load-generator/README.md
+++ b/tools/load-generator/README.md
@@ -4,5 +4,5 @@ load-generator launches groups of queries against test Prometheus instances in a
 ### Example for building the docker image
 From the repository root:
 ```
-$ make docker DOCKERFILE_PATH=tools/load-generator/Dockerfile DOCKER_IMAGE_NAME=load-generator DOCKERBUILD_CONTEXT=tools/load-generator DOCKER_IMAGE_TAG=2.0.1
+$ make docker DOCKERFILE_PATH=tools/load-generator/Dockerfile DOCKER_IMAGE_NAME=load-generator DOCKER_IMAGE_TAG=2.0.1
 ```


### PR DESCRIPTION
`DOCKERBUILD_CONTEXT` was only being used in a few images, modified the Dockerfiles to
make the Dockerfile to use the project root context like the other images.

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>