### PR TITLE
comment-monitor fixes

### DIFF
--- a/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
+++ b/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
@@ -15,7 +15,7 @@ data:
 
         - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
         - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number={{ index . "PR_NUMBER" }})
-        - [Grafana Exlorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore)
+        - [Grafana Exlorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
 
         **Other Commands:**
         To stop benchmark: `/prombench cancel`
@@ -37,7 +37,7 @@ data:
 
         - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
         - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number={{ index . "PR_NUMBER" }})
-        - [Grafana Exlorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore)
+        - [Grafana Exlorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
 
         **Other Commands:**
         To stop benchmark: `/prombench cancel`

--- a/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
+++ b/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
@@ -26,6 +26,12 @@ data:
       comment_template: |
         Benchmark cancel is in progress.
 
+    - event_type: noop
+      regex_string: (?mi)^/prombench\s*$
+      comment_template: |
+        Please add the version number to compare against.
+        Eg. `/prombench master`, `/prombench v2.12.0`
+
     - event_type: prombench_restart
       regex_string: (?mi)^/prombench\s+restart\s+(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$
       comment_template: |

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -204,6 +204,8 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		}
 
 	default:
-		log.Fatalln("only issue_comment event is supported")
+		log.Println("only issue_comment event is supported")
+		http.Error(w, "only issue_comment event is supported", http.StatusBadRequest)
+		return
 	}
 }

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -104,7 +104,6 @@ func (c *commentMonitorConfig) loadConfig() error {
 	}
 	// Get webhook secret.
 	c.whSecret, err = ioutil.ReadFile(c.whSecretFilePath)
-	fmt.Println(c.whSecret)
 	if err != nil {
 		return err
 	}

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -205,7 +205,5 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 
 	default:
 		log.Println("only issue_comment event is supported")
-		http.Error(w, "only issue_comment event is supported", http.StatusBadRequest)
-		return
 	}
 }


### PR DESCRIPTION
Added the following fixes:

- Won't fatal exit comment-monitor if unexpected event is received.
- Updated Loki explorer link in Github comment.
- Added helpful message about adding the version if someone simply uses `/prombench`

cc @krasi-georgiev 