### PR TITLE
Updated paths from prombench to test-infra and prominfra accordingly

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ version: 2.1
 # To use this config, you have to add following variables in CircleCI config:
 #   - DOCKER_LOGIN
 #   - DOCKER_PASSWORD
-#   - DOCKER_REPO (optional, default to prombench)
+#   - DOCKER_REPO (optional, default to prominfra)
 
 orbs:
   prometheus: prometheus/prometheus@0.4.0
@@ -39,7 +39,7 @@ jobs:
         name: Setup environment variables
         command: |
           echo "export DOCKER_IMAGE_TAG=`date +%Y%m%d`" >> $BASH_ENV
-          echo "export DOCKER_ORG=${DOCKER_ORG:-prombench}" >> $BASH_ENV
+          echo "export DOCKER_ORG=${DOCKER_ORG:-prominfra}" >> $BASH_ENV
     - prometheus/publish_images:
         container_image_name: prombench
         dockerfile_path: "prombench/cmd/prombench/Dockerfile"

--- a/.promu.yml
+++ b/.promu.yml
@@ -3,7 +3,7 @@ go:
     # .circle/config.yml should also be updated if in use.
     version: 1.13
 repository:
-    path: github.com/prometheus/prombench
+    path: github.com/prometheus/test-infra
 build:
     binaries:
         - name: prombench

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-DOCKER_REPO             ?= prombench
+DOCKER_REPO             ?= prominfra
 
 .PHONY: all
 all: precheck style check_license lint build test unused

--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -30,7 +30,7 @@ jobs:
 ```
 
 ## Set up
-This tools is meant to be used as a Github action. The action itself is, to a large degree, unusable alone, as you need to combine it with another Github action that will provide necessary files to it. At this time, the only action it is supposed to work with, is [comment-monitor](https://github.com/prometheus/prombench/tree/master/tools/commentMonitor).
+This tools is meant to be used as a Github action. The action itself is, to a large degree, unusable alone, as you need to combine it with another Github action that will provide necessary files to it. At this time, the only action it is supposed to work with, is [comment-monitor](https://github.com/prometheus/test-infra/tree/master/tools/commentMonitor).
 - Create Github actions workflow file that is executed when an issue comment is created, `on = "issue_comment"`.
 - Add comment-monitor Github action as a first step.
 - Specify this regex `^/funcbench ?(?P<BRANCH>[^ B\.]+)? ?(?P<REGEX>\.|Bench.*|[^ ]+)? ?(?P<RACE>-no-race)?.*$` in the `args` field of the comment-monitor.

--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -17,14 +17,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: commentMonitor
-      uses: docker://prombench/comment-monitor:latest
+      uses: docker://prominfra/comment-monitor:latest
       env:
         COMMENT_TEMPLATE: 'The benchmark has started.' // Body of a comment that is created to announce start of a benchmark.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} // Github secret token
       with:
         args: '"^/funcbench ?(?P<BRANCH>[^ B\.]+)? ?(?P<REGEX>\.|Bench.*|[^ ]+)? ?(?P<RACE>-no-race)?.*$"'
     - name: benchmark
-      uses: docker://prombench/funcbench:latest
+      uses: docker://prominfra/funcbench:latest
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} // Github secret token
 ```

--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -9,6 +9,7 @@ Specifying which tests to run are filtered by using the standard golang regex fo
 By default all benchmarks run with `-race` flag enabled and it can be disabled by appending `-no-race` at the end of the comment.
 
 ### Example Github actions workflow file
+> Note: No longer using `issue_comment`, to be replaced with commentMonitor usage.
 ```
 on: issue_comment // Workflow is executed when a pull request comment is created.
 name: Benchmark

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/prometheus/prombench
+module github.com/prometheus/test-infra
 
 go 1.12
 

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -26,9 +26,9 @@ import (
 
 	gke "cloud.google.com/go/container/apiv1"
 	"github.com/pkg/errors"
-	k8sProvider "github.com/prometheus/prombench/pkg/provider/k8s"
+	k8sProvider "github.com/prometheus/test-infra/pkg/provider/k8s"
 
-	"github.com/prometheus/prombench/pkg/provider"
+	"github.com/prometheus/test-infra/pkg/provider"
 	containerpb "google.golang.org/genproto/googleapis/container/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -35,7 +35,7 @@ import (
 
 	"strings"
 
-	"github.com/prometheus/prombench/pkg/provider"
+	"github.com/prometheus/test-infra/pkg/provider"
 
 	apiServerExtensionsV1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiServerExtensionsClient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"

--- a/prombench/cmd/prombench/Dockerfile
+++ b/prombench/cmd/prombench/Dockerfile
@@ -16,7 +16,7 @@ LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com
 RUN apk add git
 
 ENV TEST_INFRA_DIR /test-infra
-ENV TEST_INFRA_REPO https://github.com/prometheus/prombench.git
+ENV TEST_INFRA_REPO https://github.com/prometheus/test-infra.git
 
 ENV PROMBENCH_DIR $TEST_INFRA_DIR/prombench
 

--- a/prombench/cmd/prombench/prombench.go
+++ b/prombench/cmd/prombench/prombench.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main // import "github.com/prometheus/prombench/cmd/prombench"
+package main // import "github.com/prometheus/test-infra/cmd/prombench"
 
 import (
 	"fmt"
@@ -20,7 +20,7 @@ import (
 	"path/filepath"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/prombench/pkg/provider/gke"
+	"github.com/prometheus/test-infra/pkg/provider/gke"
 	"gopkg.in/alecthomas/kingpin.v2"
 )
 

--- a/prombench/manifests/cluster-infra/5b_amGithubNotifier_deployment.yaml
+++ b/prombench/manifests/cluster-infra/5b_amGithubNotifier_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: amgithubnotifier
-        image: docker.io/prombench/amgithubnotifier:0.0.1
+        image: docker.io/prominfra/amgithubnotifier:0.0.1
         args:
         - "--org={{ .GITHUB_ORG }}"
         - "--repo={{ .GITHUB_REPO }}"

--- a/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
+++ b/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: comment-monitor
     spec:
       containers:
-      - image: docker.io/prombench/comment-monitor:0.0.2
+      - image: docker.io/prominfra/comment-monitor:0.0.2
         imagePullPolicy: Always
         args:
         - "--eventmap=/etc/cm/eventmap.yml"

--- a/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
+++ b/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
@@ -23,7 +23,7 @@ data:
         spec:
           containers:
           - name: fake-webserver
-            image: docker.io/prombench/fake-webserver:2.0.1
+            image: docker.io/prominfra/fake-webserver:2.0.1
             ports:
             - name: metrics1
               containerPort: 8080
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
       - name: fake-webserver
-        image: docker.io/prombench/fake-webserver:2.0.1
+        image: docker.io/prominfra/fake-webserver:2.0.1
         ports:
         - name: metrics1
           containerPort: 8080

--- a/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
@@ -34,7 +34,7 @@ spec:
         runAsUser: 0
       initContainers:
       - name: prometheus-builder
-        image: docker.io/prombench/prometheus-builder:2.0.2
+        image: docker.io/prominfra/prometheus-builder:2.0.2
         env:
         - name: PR_NUMBER
           value: "{{ .PR_NUMBER }}"

--- a/prombench/manifests/prombench/benchmark/6_loadgen.yaml
+++ b/prombench/manifests/prombench/benchmark/6_loadgen.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: loadgen-scaler
       containers:
       - name: prom-load-generator
-        image: docker.io/prombench/scaler:2.0.0
+        image: docker.io/prominfra/scaler:2.0.0
         imagePullPolicy: Always
         args:
         - "scale"
@@ -108,7 +108,7 @@ spec:
     spec:
       containers:
       - name: prom-load-generator
-        image: docker.io/prombench/load-generator:2.0.1
+        image: docker.io/prominfra/load-generator:2.0.1
         imagePullPolicy: Always
         args:
         - "prombench-{{ .PR_NUMBER }}"

--- a/tools/scaler/scaler.go
+++ b/tools/scaler/scaler.go
@@ -25,7 +25,7 @@ import (
 	appsV1 "k8s.io/api/apps/v1"
 
 	"github.com/pkg/errors"
-	"github.com/prometheus/prombench/pkg/provider/k8s"
+	"github.com/prometheus/test-infra/pkg/provider/k8s"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"k8s.io/apimachinery/pkg/runtime"
 )


### PR DESCRIPTION
Updated go imports path and Docker image path to `test-infra` and `prominfra` accordingly.

To test this PR will need to update the images in the dockerhub org `prominfra`

cc @krasi-georgiev  @nevill 