### PR TITLE
Updated circle CI workflow name and gitignore file.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -92,7 +92,7 @@ jobs:
 
 workflows:
   version: 2
-  prombench:
+  test-infra:
     jobs:
     - build_and_test:
         filters:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/fake-webserver
-/scaler
-/amGithubNotifier
-/commentMonitor
-/funcbench
+/tools/amGithubNotifier/amGithubNotifier
+/tools/commentMonitor/commentMonitor
+/tools/fake-webserver/fake-webserver
+/tools/scaler/scaler
+/funcbench/funcbench


### PR DESCRIPTION
Circle CI tests were not working probably due to workflow name change, this updates the circle ci config file aswell updates the gitignore file to ignore builds.

related #326 

Signed-off-by: Hrishikesh Barman <plain.hrishikeshbman@gmail.com>