### PR TITLE
Update Docker image tag to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
     - run:
         name: Setup environment variables
         command: |
-          echo "export DOCKER_IMAGE_TAG=`date +%Y%m%d`" >> $BASH_ENV
+          echo "export DOCKER_IMAGE_TAG=master" >> $BASH_ENV
           echo "export DOCKER_ORG=${DOCKER_ORG:-prominfra}" >> $BASH_ENV
     - prometheus/publish_images:
         container_image_name: prombench
@@ -85,6 +85,13 @@ jobs:
     - prometheus/publish_images:
         container_image_name: load-generator
         dockerfile_path: "tools/load-generator/Dockerfile"
+        registry: docker.io
+        organization: "$DOCKER_ORG"
+        login_variable: DOCKER_LOGIN
+        password_variable: DOCKER_PASSWORD
+    - prometheus/publish_images:
+        container_image_name: prometheus-builder
+        dockerfile_path: "prombench/temp/prometheus-builder/Dockerfile"
         registry: docker.io
         organization: "$DOCKER_ORG"
         login_variable: DOCKER_LOGIN

--- a/prombench/manifests/cluster-infra/5b_amGithubNotifier_deployment.yaml
+++ b/prombench/manifests/cluster-infra/5b_amGithubNotifier_deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: amgithubnotifier
-        image: docker.io/prominfra/amgithubnotifier:0.0.1
+        image: docker.io/prominfra/amgithubnotifier:master
         args:
         - "--org={{ .GITHUB_ORG }}"
         - "--repo={{ .GITHUB_REPO }}"

--- a/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
+++ b/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: comment-monitor
     spec:
       containers:
-      - image: docker.io/prominfra/comment-monitor:0.0.2
+      - image: docker.io/prominfra/comment-monitor:master
         imagePullPolicy: Always
         args:
         - "--eventmap=/etc/cm/eventmap.yml"

--- a/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
+++ b/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
@@ -23,7 +23,7 @@ data:
         spec:
           containers:
           - name: fake-webserver
-            image: docker.io/prominfra/fake-webserver:2.0.1
+            image: docker.io/prominfra/fake-webserver:master
             ports:
             - name: metrics1
               containerPort: 8080

--- a/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
+++ b/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
@@ -57,7 +57,7 @@ spec:
     spec:
       containers:
       - name: fake-webserver
-        image: docker.io/prominfra/fake-webserver:2.0.1
+        image: docker.io/prominfra/fake-webserver:master
         ports:
         - name: metrics1
           containerPort: 8080

--- a/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
@@ -34,7 +34,7 @@ spec:
         runAsUser: 0
       initContainers:
       - name: prometheus-builder
-        image: docker.io/prominfra/prometheus-builder:2.0.2
+        image: docker.io/prominfra/prometheus-builder:master
         env:
         - name: PR_NUMBER
           value: "{{ .PR_NUMBER }}"

--- a/prombench/manifests/prombench/benchmark/6_loadgen.yaml
+++ b/prombench/manifests/prombench/benchmark/6_loadgen.yaml
@@ -68,7 +68,7 @@ spec:
       serviceAccountName: loadgen-scaler
       containers:
       - name: prom-load-generator
-        image: docker.io/prominfra/scaler:2.0.0
+        image: docker.io/prominfra/scaler:master
         imagePullPolicy: Always
         args:
         - "scale"
@@ -108,7 +108,7 @@ spec:
     spec:
       containers:
       - name: prom-load-generator
-        image: docker.io/prominfra/load-generator:2.0.1
+        image: docker.io/prominfra/load-generator:master
         imagePullPolicy: Always
         args:
         - "prombench-{{ .PR_NUMBER }}"


### PR DESCRIPTION
- Automated docker image push will push images with tag `master`, updated corresponding docker image tags in manifest files using these images in this PR.
- Added `prometheus-builder` image to be built automatically as-well.


