### PR TITLE
Refactor commentMonitor to use go-githubv29

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go v0.39.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-github/v26 v26.1.3
+	github.com/google/go-github/v29 v29.0.3
 	github.com/google/gofuzz v1.0.0 // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect
 	github.com/imdario/mergo v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,8 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCydnIczKteheJEzHRToSGK3Bnlw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
@@ -75,6 +77,8 @@ github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4r
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v26 v26.1.3 h1:n03e8IGgLdD78L+ETWxvqpBIBWEZLlTBCQVU2yImw1o=
 github.com/google/go-github/v26 v26.1.3/go.mod h1:v6/FmX9au22j4CtYxnMhJJkP+JfOQDXALk7hI+MPDNM=
+github.com/google/go-github/v29 v29.0.3 h1:IktKCTwU//aFHnpA+2SLIi7Oo9uhAzgsdZNbcAqhgdc=
+github.com/google/go-github/v29 v29.0.3/go.mod h1:CHKiKKPHJ0REzfwc14QMklvtHwCveD0PxlMjLlzAM5E=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v1.0.0 h1:A8PeW59pxE9IoFRqBp37U+mSNaQoZ46F1f0f863XSXw=

--- a/tools/commentMonitor/client.go
+++ b/tools/commentMonitor/client.go
@@ -72,6 +72,7 @@ func (c commentMonitorClient) verifyUser(ctx context.Context, verifyUserDisabled
 
 // Extract args if regexString provided.
 func (c *commentMonitorClient) extractArgs(ctx context.Context) error {
+	var err error
 	if c.regex != nil {
 		// Add comment arguments.
 		commentArgs := c.regex.FindStringSubmatch(c.ghClient.commentBody)[1:]
@@ -85,12 +86,15 @@ func (c *commentMonitorClient) extractArgs(ctx context.Context) error {
 
 		// Add non-comment arguments if any.
 		c.allArgs["PR_NUMBER"] = strconv.Itoa(c.ghClient.pr)
+		c.allArgs["LAST_COMMIT_SHA"], err = c.ghClient.getLastCommitSHA(ctx)
+		if err != nil {
+			return fmt.Errorf("%v: could not fetch SHA", err)
+		}
 
-		err := c.ghClient.createRepositoryDispatch(ctx, c.eventType, c.allArgs)
+		err = c.ghClient.createRepositoryDispatch(ctx, c.eventType, c.allArgs)
 		if err != nil {
 			return fmt.Errorf("%v: could not create repository_dispatch event", err)
 		}
-
 	}
 	return nil
 }

--- a/tools/commentMonitor/client.go
+++ b/tools/commentMonitor/client.go
@@ -34,7 +34,8 @@ type commentMonitorClient struct {
 	commentTemplate string
 }
 
-// Validate comment if regexString provided.
+// Set eventType and commentTemplate if
+// regexString is validated against provided commentBody.
 func (c *commentMonitorClient) validateRegex() bool {
 	for _, e := range c.eventMap {
 		c.regex = regexp.MustCompile(e.RegexString)

--- a/tools/commentMonitor/ghclient.go
+++ b/tools/commentMonitor/ghclient.go
@@ -48,6 +48,9 @@ func (c githubClient) getLastCommitSHA(ctx context.Context) (string, error) {
 	// https://developer.github.com/v3/pulls/#list-commits-on-a-pull-request
 	listops := &github.ListOptions{Page: 1, PerPage: 250}
 	l, _, err := c.clt.PullRequests.ListCommits(ctx, c.owner, c.repo, c.pr, listops)
+	if len(l) == 0 {
+		return "", fmt.Errorf("pr does not have a commit")
+	}
 	return l[len(l)-1].GetSHA(), err
 }
 

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -37,7 +37,7 @@ type commentMonitorConfig struct {
 	port               string
 }
 
-// Structure of eventmap.yaml file.
+// Structure of eventmap.yml file.
 type webhookEventMap struct {
 	EventType       string `yaml:"event_type"`
 	CommentTemplate string `yaml:"comment_template"`
@@ -71,7 +71,7 @@ func main() {
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", cmConfig.port), mux))
 }
 
-func newGithubClientForIssueComments(ctx context.Context, e *github.IssueCommentEvent) (*githubClient, error) {
+func newGithubClient(ctx context.Context, e *github.IssueCommentEvent) (*githubClient, error) {
 	ghToken := os.Getenv("GITHUB_TOKEN")
 	if ghToken == "" {
 		return nil, fmt.Errorf("env var missing")
@@ -148,7 +148,7 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 
 		// Setup github client.
 		ctx := context.Background()
-		cmClient.ghClient, err = newGithubClientForIssueComments(ctx, e)
+		cmClient.ghClient, err = newGithubClient(ctx, e)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, "could not create GitHub client", http.StatusBadRequest)

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/google/go-github/v26/github"
+	"github.com/google/go-github/v29/github"
 	"golang.org/x/oauth2"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v2"
@@ -167,14 +167,6 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		if err != nil {
 			log.Println(err)
 			http.Error(w, "user not allowed to run command", http.StatusForbidden)
-			return
-		}
-
-		// Get the last commit sha from PR.
-		cmClient.allArgs["LAST_COMMIT_SHA"], err = cmClient.ghClient.getLastCommitSHA(ctx)
-		if err != nil {
-			log.Println(err)
-			http.Error(w, "could not fetch sha", http.StatusBadRequest)
 			return
 		}
 


### PR DESCRIPTION
Support for `repository_dispatch` was added to go-github : https://github.com/google/go-github/pull/1306

This PR updates commentMonitor to use go-githubv29 and added some minor refactoring.