### PR TITLE
Added make back to prombench Dockerfile.

### DIFF
--- a/prombench/cmd/prombench/Dockerfile
+++ b/prombench/cmd/prombench/Dockerfile
@@ -13,7 +13,7 @@ RUN CGO_ENABLED=0 GO111MODULE=on go build -a -tags netgo -o /go/bin/prombench
 FROM alpine:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
-RUN apk add git
+RUN apk add git make
 
 ENV TEST_INFRA_DIR /test-infra
 ENV TEST_INFRA_REPO https://github.com/prometheus/test-infra.git


### PR DESCRIPTION
Installing `make` is essential for running the prombench docker image since the base alpine image does not have it by default. It was removed in #320 and got overlooked, this PR adds it back.


cc: @krasi-georgiev @nevill 


Signed-off-by: Hrishikesh Barman <plain.hrishikeshbman@gmail.com>