### PR TITLE
Refactoring and documenting funcbench

### DIFF
--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -1,100 +1,33 @@
 # funcbench
 
-A tool used as a github action to run a `go test -bench` and compare changes from a PR against another branch or commit.
+Benchmark and compare your Go code between commits or sub benchmarks. It uses `go test -bench` to run the benchmarks and uses [benchcmp](https://godoc.org/golang.org/x/tools/cmd/benchcmp) to compare them.
 
-The benchmark can be triggered by creating a comment which specifies a branch to compare. The results are then posted back as a PR comment.
-The benchmark can be also trigger and used as CLI command, without GitHub hook.
+funcbench currently supports two modes, Local and GitHub. Running it in the Github Mode also allows it to accept *a pull request number* and *a branch/commit* to compare against, which makes it suitable for automated tests.
 
-Comparison is done using [benchcmp](https://godoc.org/golang.org/x/tools/cmd/benchcmp).
-Arguments for the benchcmp are read from files created by previous action (for example [commentMonitor](/tools/commentMonitor/main.go)),
-which is responsible for the comment parsing.
+### Environment variables
+- `GITHUB_TOKEN`: Access token to post benchmarks results to respective PR.
 
-## Usage
+## Usage Examples
+> Clean git state is required.
 
-NOTE: Clean git state is required.
-Examples:
+|Usage|Command|
+|--|--|
+|Execute benchmark named `BenchmarkFuncName` regex, and compare it with `master` branch. | ``` ./funcbench -v master BenchmarkFuncName ``` |
+|Execute all benchmarks matching `BenchmarkFuncName.*` regex, and compare it with `master` branch.|```./funcbench -v master BenchmarkFuncName.*```|
+|Execute all benchmarks, and compare the results with `devel` branch.|```./funcbench -v devel . ```|
+|Execute all benchmarks matching `BenchmarkFuncName.*` regex, and compare it with `6d280faa16bfca1f26fa426d863afbb564c063d1` commit.|```./funcbench -v 6d280faa16bfca1f26fa426d863afbb564c063d1 BenchmarkFuncName.*```|
+|Execute all benchmarks matching `BenchmarkFuncName.*` regex on current code. Compare it between sub-benchmarks (`b.Run`) of same benchmark for current commit. Errors out if there are no sub-benchmarks.|```./funcbench -v . FuncName.*```|
+|Execute benchmark named `BenchmarkFuncName`, and compare `pr#35` with `master` branch.|```./funcbench --dryrun --github-pr="35" master BenchmarkFuncName```|
 
-* Execute benchmark named `FuncName` regex, and compare it with `master` branch.
-
- ```
- /funcbench -v master BenchmarkFuncName
- ```
-
-* Execute all benchmarks matching `FuncName.*` regex, and compare it with `master` branch.
-
+## Triggering with GitHub comments
+The benchmark can be triggered by creating a comment in a PR which specifies a branch to compare. The results are then posted back to the PR as a comment.
 ```
- /funcbench -v master FuncName.*
- ```
-
-* Execute all benchmarks, and compare the results with `devel` branch.
-
- ```
- /funcbench -v devel .
- ```
-
-* Execute all benchmarks matching `FuncName.*` regex, and compare it with `6d280faa16bfca1f26fa426d863afbb564c063d1` commit.
-
- ```
- /funcbench -v 6d280faa16bfca1f26fa426d863afbb564c063d1 FuncName.*
- ```
-
-* Execute all benchmarks matching `FuncName.*` regex on current code. Compare it between sub-benchmarks (`b.Run`) of same benchmark for current commit.
-Errors out if there are no sub-benchmarks.
-
- ```
- /funcbench -v . FuncName.*
- ```
-
-### GitHub
-
-Tests are triggered by posting a comment in a PR with the following format:
-
-`/funcbench <branch/commit> <Go test regex>`
-
-Specifying which tests to run are filtered by using the standard [Go regex RE2 language](https://github.com/google/re2/wiki/Syntax).
-
-* To test it locally, set `-w` flag or `WORKSPACE` environment variable to an empty directory where the source will be cloned.
-
-By default all benchmarks run without `-race` flag (#275).
-
-#### Example Github actions workflow file to pass in --input flag.
-
-> TODO: No longer using `issue_comment`, to be replaced with commentMonitor usage.
-
-```
-on: issue_comment // Workflow is executed when a pull request comment is created.
-name: Benchmark
-jobs:
-  commentMonitor:
-    runs-on: ubuntu-latest
-    steps:
-    - name: commentMonitor
-      uses: docker://prominfra/comment-monitor:latest
-      env:
-        COMMENT_TEMPLATE: 'The benchmark has started.' // Body of a comment that is created to announce start of a benchmark.
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} // Github secret token/
-      with:
-        args: '"^/funcbench ?(?P<BRANCH>[^ B\.]+)? ?(?P<REGEX>\.|Bench.*|[^ ]+)?'
-    - name: benchmark
-      uses: docker://prominfra/funcbench:latest
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} // Github secret token/
+/funcbench <branch/commit> <benchmark function regex>
 ```
 
-#### Set up
-
-This tool is meant to be used with a Github action. The action itself is, to a large degree, unusable alone, as you need
-to combine it with another Github action that will provide necessary files to it. At this time, the only action it is
-supposed to work with, is [comment-monitor](https://github.com/prometheus/prombench/tree/master/tools/commentMonitor).
-
-- Create Github actions workflow file that is executed when an issue comment is created, `on = "issue_comment"`.
-- Add comment-monitor Github action as a first step.
-- Specify this regex `^/funcbench ?(?P<BRANCH>[^ B\.]+)? ?(?P<REGEX>\.|Bench.*|[^ ]+)?` in the `args` field of the comment-monitor.
-- Specify this Github action as a pre-built image, build from this source code, or just refer to this repository from the workflow file.
-- Provide a Github token as an environment variable to both comment-monitor and funcbench.
+The comment is handled by [comment-monitor](https://github.com/prometheus/test-infra/tree/master/tools/commentMonitor) and then the parsed arguments are handed over to funcbench(if using Github Actions) or to [prombench](https://github.com/prometheus/test-infra/tree/master/prombench) if using funcbench with GKE.
 
 ## Building Docker container.
-
 From the repository root:
 
 `docker build -t <tag of your choice> -f funcbench/Dockerfile .`

--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -1,13 +1,15 @@
 # funcbench
 
-Benchmark and compare your Go code between commits or sub benchmarks. It uses `go test -bench` to run the benchmarks and uses [benchcmp](https://godoc.org/golang.org/x/tools/cmd/benchcmp) to compare them.
+Benchmark and compare your Go code between commits or sub benchmarks. It automated the use of `go test -bench` to run the benchmarks and uses [benchcmp](https://godoc.org/golang.org/x/tools/cmd/benchcmp) to compare them.
 
-funcbench currently supports two modes, Local and GitHub. Running it in the Github Mode also allows it to accept *a pull request number* and *a branch/commit* to compare against, which makes it suitable for automated tests.
+funcbench currently supports two modes, Local and GitHub. Running it in the Github mode also allows it to accept *a pull request number* and *a branch/commit* to compare against, which makes it suitable for automated tests.
 
-### Environment variables
+## Environment variables
+
 - `GITHUB_TOKEN`: Access token to post benchmarks results to respective PR.
 
 ## Usage Examples
+
 > Clean git state is required.
 
 |Usage|Command|
@@ -20,6 +22,7 @@ funcbench currently supports two modes, Local and GitHub. Running it in the Gith
 |Execute benchmark named `BenchmarkFuncName`, and compare `pr#35` with `master` branch.|```./funcbench --dryrun --github-pr="35" master BenchmarkFuncName```|
 
 ## Triggering with GitHub comments
+
 The benchmark can be triggered by creating a comment in a PR which specifies a branch to compare. The results are then posted back to the PR as a comment.
 ```
 /funcbench <branch/commit> <benchmark function regex>
@@ -28,6 +31,7 @@ The benchmark can be triggered by creating a comment in a PR which specifies a b
 The comment is handled by [comment-monitor](https://github.com/prometheus/test-infra/tree/master/tools/commentMonitor) and then the parsed arguments are handed over to funcbench(if using Github Actions) or to [prombench](https://github.com/prometheus/test-infra/tree/master/prombench) if using funcbench with GKE.
 
 ## Building Docker container.
+
 From the repository root:
 
 `docker build -t <tag of your choice> -f funcbench/Dockerfile .`

--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -1,6 +1,6 @@
 # funcbench
 
-Benchmark and compare your Go code between commits or sub benchmarks. It automated the use of `go test -bench` to run the benchmarks and uses [benchcmp](https://godoc.org/golang.org/x/tools/cmd/benchcmp) to compare them.
+Benchmark and compare your Go code between commits or sub benchmarks. It automates the use of `go test -bench` to run the benchmarks and uses [benchcmp](https://godoc.org/golang.org/x/tools/cmd/benchcmp) to compare them.
 
 funcbench currently supports two modes, Local and GitHub. Running it in the Github mode also allows it to accept *a pull request number* and *a branch/commit* to compare against, which makes it suitable for automated tests.
 

--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -19,7 +19,7 @@ funcbench currently supports two modes, Local and GitHub. Running it in the Gith
 |Execute all benchmarks, and compare the results with `devel` branch.|```./funcbench -v devel . ```|
 |Execute all benchmarks matching `BenchmarkFuncName.*` regex, and compare it with `6d280faa16bfca1f26fa426d863afbb564c063d1` commit.|```./funcbench -v 6d280faa16bfca1f26fa426d863afbb564c063d1 BenchmarkFuncName.*```|
 |Execute all benchmarks matching `BenchmarkFuncName.*` regex on current code. Compare it between sub-benchmarks (`b.Run`) of same benchmark for current commit. Errors out if there are no sub-benchmarks.|```./funcbench -v . FuncName.*```|
-|Execute benchmark named `BenchmarkFuncName`, and compare `pr#35` with `master` branch.|```./funcbench --dryrun --github-pr="35" master BenchmarkFuncName```|
+|Execute benchmark named `BenchmarkFuncName`, and compare `pr#35` with `master` branch.|```./funcbench --nocomment --github-pr="35" master BenchmarkFuncName```|
 
 ## Triggering with GitHub comments
 

--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -84,8 +84,7 @@ func (b *Benchmarker) execBenchmark(pkgRoot string, commit plumbing.Hash) (out s
 	extraArgs = append(extraArgs, "-timeout", b.benchTimeout.String())
 	benchCmd := []string{"bash", "-c", strings.Join(append(append([]string{"cd", pkgRoot, "&&", "go", "test", "-run", "^$", "-bench", fmt.Sprintf("^%s$", b.benchFunc), "-benchmem"}, extraArgs...), "./..."), " ")}
 
-	b.logger.Println("Executing benchmark command for", commit.String())
-	b.logger.Println(benchCmd)
+	b.logger.Println("Executing benchmark command for", commit.String(), "\n", benchCmd)
 	out, err = b.c.exec(benchCmd...)
 	if err != nil {
 		return "", errors.Wrap(err, "benchmark ended with an error.")

--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -152,19 +152,19 @@ func formatCommentToMD(rawTable string) string {
 		switch {
 		case e == "":
 
-		case strings.Contains(e, "old ns/op"):
+		case strings.Contains(e, "ns/op"):
 			e = "| Benchmark | Old ns/op | New ns/op | Delta |"
 			tableContent = append(tableContent[:i+1], append([]string{"|-|-|-|-|"}, tableContent[i+1:]...)...)
 
-		case strings.Contains(e, "old MB/s"):
+		case strings.Contains(e, "MB/s"):
 			e = "| Benchmark | Old MB/s | New MB/s | Speedup |"
 			tableContent = append(tableContent[:i+1], append([]string{"|-|-|-|-|"}, tableContent[i+1:]...)...)
 
-		case strings.Contains(e, "old allocs"):
+		case strings.Contains(e, "allocs"):
 			e = "| Benchmark | Old allocs | New allocs | Delta |"
 			tableContent = append(tableContent[:i+1], append([]string{"|-|-|-|-|"}, tableContent[i+1:]...)...)
 
-		case strings.Contains(e, "old bytes"):
+		case strings.Contains(e, "bytes"):
 			e = "| Benchmark | Old bytes | New bytes | Delta |"
 			tableContent = append(tableContent[:i+1], append([]string{"|-|-|-|-|"}, tableContent[i+1:]...)...)
 

--- a/funcbench/cmp.go
+++ b/funcbench/cmp.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"math"
 	"sort"
+	"strconv"
 	"text/tabwriter"
 
 	"golang.org/x/tools/benchmark/parse"
@@ -157,6 +158,19 @@ func (x ByDeltaAllocsPerOp) Len() int      { return len(x) }
 func (x ByDeltaAllocsPerOp) Swap(i, j int) { x[i], x[j] = x[j], x[i] }
 func (x ByDeltaAllocsPerOp) Less(i, j int) bool {
 	return lessByDelta(x[i], x[j], BenchCmp.DeltaAllocsPerOp)
+}
+
+// formatNs formats ns measurements to expose a useful amount of
+// precision. It mirrors the ns precision logic of testing.B.
+func formatNs(ns float64) string {
+	prec := 0
+	switch {
+	case ns < 10:
+		prec = 2
+	case ns < 100:
+		prec = 1
+	}
+	return strconv.FormatFloat(ns, 'f', prec, 64)
 }
 
 // Copied from https://github.com/golang/tools/blob/master/cmd/benchcmp/benchcmp.go.

--- a/funcbench/env.go
+++ b/funcbench/env.go
@@ -98,17 +98,9 @@ type GitHub struct {
 	logLink string
 }
 
-func newGitHubEnv(ctx context.Context, e environment, owner, repo string, prNumber int) (Environment, error) {
-	if e.home == "" {
-		e.home = "."
-	}
-
-	if err := os.Chdir(e.home); err != nil {
-		return nil, err
-	}
-
+func newGitHubEnv(ctx context.Context, e environment, owner, repo, workspace string, prNumber int) (Environment, error) {
 	ghClient := newGitHubClient(owner, repo, prNumber)
-	r, err := git.PlainCloneContext(ctx, fmt.Sprintf("%s/%s", e.home, ghClient.repo), false, &git.CloneOptions{
+	r, err := git.PlainCloneContext(ctx, fmt.Sprintf("%s/%s", workspace, ghClient.repo), false, &git.CloneOptions{
 		URL:      fmt.Sprintf("https://github.com/%s/%s.git", ghClient.owner, ghClient.repo),
 		Progress: os.Stdout,
 		Depth:    1,
@@ -118,8 +110,8 @@ func newGitHubEnv(ctx context.Context, e environment, owner, repo string, prNumb
 		return nil, errors.Wrap(err, "git clone")
 	}
 
-	if err := os.Chdir(filepath.Join(os.Getenv("GITHUB_WORKSPACE"), ghClient.repo)); err != nil {
-		return nil, errors.Wrapf(err, "changing to GITHUB_WORKSPACE/%s dir", ghClient.repo)
+	if err := os.Chdir(filepath.Join(workspace, ghClient.repo)); err != nil {
+		return nil, errors.Wrapf(err, "changing to %s/%s dir", workspace, ghClient.repo)
 	}
 
 	g := &GitHub{

--- a/funcbench/env.go
+++ b/funcbench/env.go
@@ -140,32 +140,32 @@ func (g *GitHub) PostResults(cmps []BenchCmp) error {
 func (g *GitHub) Repo() *git.Repository { return g.repo }
 
 type gitHubClient struct {
-	owner    string
-	repo     string
-	prNumber int
-	client   *github.Client
-	dryrun   bool
+	owner     string
+	repo      string
+	prNumber  int
+	client    *github.Client
+	nocomment bool
 }
 
-func newGitHubClient(ctx context.Context, owner, repo string, prNumber int, dryrun bool) (*gitHubClient, error) {
+func newGitHubClient(ctx context.Context, owner, repo string, prNumber int, nocomment bool) (*gitHubClient, error) {
 	ghToken, ok := os.LookupEnv("GITHUB_TOKEN")
-	if !ok && !dryrun {
+	if !ok && !nocomment {
 		return nil, fmt.Errorf("GITHUB_TOKEN missing")
 	}
 	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: ghToken})
 	tc := oauth2.NewClient(ctx, ts)
 	c := gitHubClient{
-		client:   github.NewClient(tc),
-		owner:    owner,
-		repo:     repo,
-		prNumber: prNumber,
-		dryrun:   dryrun,
+		client:    github.NewClient(tc),
+		owner:     owner,
+		repo:      repo,
+		prNumber:  prNumber,
+		nocomment: nocomment,
 	}
 	return &c, nil
 }
 
 func (c *gitHubClient) postComment(comment string) error {
-	if c.dryrun {
+	if c.nocomment {
 		return nil
 	}
 

--- a/funcbench/env.go
+++ b/funcbench/env.go
@@ -58,9 +58,7 @@ func newLocalEnv(e environment) (Environment, error) {
 	if err != nil {
 		return nil, err
 	}
-	e.logger.Println("[Local Mode]")
-	e.logger.Println("Benchmarking current version versus:", e.compareTarget)
-	e.logger.Println("Benchmark func regex:", e.benchFunc)
+	e.logger.Println("[Local Mode]", "\nBenchmarking current version versus:", e.compareTarget, "\nBenchmark func regex:", e.benchFunc)
 	return &Local{environment: e, repo: r}, nil
 }
 
@@ -89,11 +87,11 @@ func newGitHubEnv(ctx context.Context, e environment, gc *gitHubClient, workspac
 		Depth:    1,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not clone git repository")
+		return nil, errors.Wrap(err, "clone git repository")
 	}
 
 	if err := os.Chdir(filepath.Join(workspace, gc.repo)); err != nil {
-		return nil, errors.Wrapf(err, "changing to %s/%s dir failed", workspace, gc.repo)
+		return nil, errors.Wrapf(err, "changing to %s/%s dir", workspace, gc.repo)
 	}
 
 	g := &GitHub{
@@ -113,18 +111,16 @@ func newGitHubEnv(ctx context.Context, e environment, gc *gitHubClient, workspac
 		},
 		Progress: os.Stdout,
 	}); err != nil && err != git.NoErrAlreadyUpToDate {
-		return nil, errors.Wrap(err, "fetch to pull request branch failed")
+		return nil, errors.Wrap(err, "fetch to pull request branch")
 	}
 
 	if err = wt.Checkout(&git.CheckoutOptions{
 		Branch: plumbing.NewBranchReferenceName("pullrequest"),
 	}); err != nil {
-		return nil, errors.Wrap(err, "switch to pull request branch failed")
+		return nil, errors.Wrap(err, "switch to pull request branch")
 	}
 
-	e.logger.Println("[GitHub Mode]", gc.owner, ":", gc.repo)
-	e.logger.Println("Benchmarking PR -", gc.prNumber, "versus:", e.compareTarget)
-	e.logger.Println("Benchmark func regex:", e.benchFunc)
+	e.logger.Println("[GitHub Mode]", gc.owner, ":", gc.repo, "\nBenchmarking PR -", gc.prNumber, "versus:", e.compareTarget, "\nBenchmark func regex:", e.benchFunc)
 	return g, nil
 }
 

--- a/funcbench/main.go
+++ b/funcbench/main.go
@@ -53,6 +53,7 @@ func (l *logger) FatalError(err error) {
 func main() {
 	cfg := struct {
 		verbose        bool
+		dryrun         bool
 		owner          string
 		repo           string
 		resultsDir     string
@@ -73,6 +74,8 @@ func main() {
 	app.HelpFlag.Short('h')
 	app.Flag("verbose", "Verbose mode. Errors includes trace and commands output are logged.").
 		Short('v').BoolVar(&cfg.verbose)
+	app.Flag("dryrun", "Dryrun for the GitHub API.").
+		BoolVar(&cfg.dryrun)
 
 	app.Flag("owner", "A Github owner or organisation name.").
 		Default("prometheus").StringVar(&cfg.owner)
@@ -135,7 +138,7 @@ func main() {
 				}
 			} else {
 				// Github Mode.
-				ghClient, err := newGitHubClient(ctx, cfg.owner, cfg.repo, cfg.ghPr)
+				ghClient, err := newGitHubClient(ctx, cfg.owner, cfg.repo, cfg.ghPr, cfg.dryrun)
 				if err != nil {
 					return errors.Wrapf(err, "could not create github client")
 				}

--- a/funcbench/main.go
+++ b/funcbench/main.go
@@ -134,7 +134,7 @@ func main() {
 				// Local Mode.
 				env, err = newLocalEnv(e)
 				if err != nil {
-					return errors.Wrap(err, "environment creation")
+					return errors.Wrap(err, "environment create")
 				}
 			} else {
 				// Github Mode.
@@ -148,7 +148,7 @@ func main() {
 					if err := ghClient.postComment(fmt.Sprintf("%v. Could not setup environment, please check logs.", err)); err != nil {
 						return errors.Wrap(err, "could not post error")
 					}
-					return errors.Wrap(err, "environment creation")
+					return errors.Wrap(err, "environment create")
 				}
 			}
 

--- a/funcbench/main.go
+++ b/funcbench/main.go
@@ -156,7 +156,7 @@ func main() {
 			cmps, err := startBenchmark(ctx, env, newBenchmarker(logger, env, &commander{verbose: cfg.verbose}, cfg.benchTime, cfg.benchTimeout, cfg.resultsDir))
 			if err != nil {
 				if pErr := env.PostErr(fmt.Sprintf("%v. Benchmark failed, please check logs.", err)); pErr != nil {
-					return errors.Wrap(err, "could not log error")
+					return errors.Wrap(pErr, "could not log error")
 				}
 				return err
 			}

--- a/funcbench/main.go
+++ b/funcbench/main.go
@@ -243,6 +243,7 @@ func startBenchmark(
 		return nil, errors.Wrapf(err, "delete worktree at %s", cmpWorkTreeDir)
 	}
 
+	// TODO (geekodour): switch to worktree remove once we decide not to support git<2.17
 	if _, err := bench.c.exec("git", "worktree", "prune"); err != nil {
 		return nil, errors.Wrap(err, "worktree prune")
 	}

--- a/funcbench/main.go
+++ b/funcbench/main.go
@@ -53,7 +53,7 @@ func (l *logger) FatalError(err error) {
 func main() {
 	cfg := struct {
 		verbose        bool
-		dryrun         bool
+		nocomment      bool
 		owner          string
 		repo           string
 		resultsDir     string
@@ -74,8 +74,8 @@ func main() {
 	app.HelpFlag.Short('h')
 	app.Flag("verbose", "Verbose mode. Errors includes trace and commands output are logged.").
 		Short('v').BoolVar(&cfg.verbose)
-	app.Flag("dryrun", "Dryrun for the GitHub API.").
-		BoolVar(&cfg.dryrun)
+	app.Flag("nocomment", "Disable posting of comment using the GitHub API.").
+		BoolVar(&cfg.nocomment)
 
 	app.Flag("owner", "A Github owner or organisation name.").
 		Default("prometheus").StringVar(&cfg.owner)
@@ -138,7 +138,7 @@ func main() {
 				}
 			} else {
 				// Github Mode.
-				ghClient, err := newGitHubClient(ctx, cfg.owner, cfg.repo, cfg.ghPR, cfg.dryrun)
+				ghClient, err := newGitHubClient(ctx, cfg.owner, cfg.repo, cfg.ghPR, cfg.nocomment)
 				if err != nil {
 					return errors.Wrapf(err, "github client")
 				}

--- a/funcbench/main.go
+++ b/funcbench/main.go
@@ -104,7 +104,7 @@ func main() {
 		Required().StringVar(&cfg.compareTarget)
 	app.Arg("function-regex", "Function regex to use for benchmark."+
 		"Supports RE2 regexp and is fully anchored, by default will run all benchmarks.").
-		Default(".").
+		Default(".*").
 		StringVar(&cfg.benchFuncRegex) // TODO (geekodour) : validate regex?
 
 	kingpin.MustParse(app.Parse(os.Args[1:]))

--- a/funcbench/main_test.go
+++ b/funcbench/main_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestMarkdownFormatting(t *testing.T) {
+	expectedTable := `| Benchmark | Old ns/op | New ns/op | Delta |
+|-|-|-|-|
+BenchmarkBufferedSeriesIterator-8|15.7|15.6|-0.64%
+
+| Benchmark | Old MB/s | New MB/s | Speedup |
+|-|-|-|-|
+BenchmarkBufferedSeriesIterator-8|78201671850.73|79045143860.06|1.01x
+
+| Benchmark | Old allocs | New allocs | Delta |
+|-|-|-|-|
+BenchmarkBufferedSeriesIterator-8|0|0|+0.00%
+
+| Benchmark | Old bytes | New bytes | Delta |
+|-|-|-|-|
+BenchmarkBufferedSeriesIterator-8|0|0|+0.00%`
+	rawTable := `benchmark master ns/op new ns/op delta
+BenchmarkBufferedSeriesIterator-8 15.7 15.6 -0.64%
+
+benchmark master MB/s new MB/s speedup
+BenchmarkBufferedSeriesIterator-8 78201671850.73 79045143860.06 1.01x
+
+benchmark master allocs new allocs delta
+BenchmarkBufferedSeriesIterator-8 0 0 +0.00%
+
+benchmark master bytes new bytes delta
+BenchmarkBufferedSeriesIterator-8 0 0 +0.00%`
+	formattedTable := formatCommentToMD(rawTable)
+	if formattedTable != expectedTable {
+		t.Errorf("Output did not match.\ngot:\n%#v\nwant:\n%#v", formattedTable, expectedTable)
+	}
+}


### PR DESCRIPTION
This PR does not add any new feature expect ~`--dryrun`~ `--nocomment` flag, It's mostly refactoring, reordering and fixing some bugs/missing features.

Changes:
- Updated readme and removed all old Github Action references.
- Removed the use of `GITHUB_WORKSPACE` completely inside funcbench and added command line arguments into a configuration variable.
- Improved logging and comments
- Renamed `funcbench` to `startBenchmark`
- Renamed `compareTargetRef` to `getTargetInfo`
- Added ~`--dryrun`~ `--nocomment` flag
- Added test for `formatCommentToMD`
- Enables tests to be run from commit hash as the target

Please let me know if I should split this PR into multiple PRs by the commits.
cc: @krasi-georgiev @nevill @bwplotka 