### PR TITLE
Use Context.context in command execution for funcbench

### DIFF
--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -14,6 +14,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -67,7 +68,7 @@ func (b *Benchmarker) benchOutFileName(commit plumbing.Hash) (string, error) {
 	return fmt.Sprintf("%s-%s.out", bb.String(), commit.String()), nil
 }
 
-func (b *Benchmarker) execBenchmark(pkgRoot string, commit plumbing.Hash) (out string, err error) {
+func (b *Benchmarker) execBenchmark(ctx context.Context, pkgRoot string, commit plumbing.Hash) (out string, err error) {
 	fileName, err := b.benchOutFileName(commit)
 	if err != nil {
 		return "", err
@@ -85,7 +86,7 @@ func (b *Benchmarker) execBenchmark(pkgRoot string, commit plumbing.Hash) (out s
 	benchCmd := []string{"sh", "-c", strings.Join(append(append([]string{"cd", pkgRoot, "&&", "go", "test", "-run", "^$", "-bench", fmt.Sprintf("^%s$", b.benchFunc), "-benchmem"}, extraArgs...), "./..."), " ")}
 
 	b.logger.Println("Executing benchmark command for", commit.String(), "\n", benchCmd)
-	out, err = b.c.exec(benchCmd...)
+	out, err = b.c.exec(ctx, benchCmd...)
 	if err != nil {
 		return "", errors.Wrap(err, "benchmark ended with an error.")
 	}

--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -68,7 +68,7 @@ func (b *Benchmarker) benchOutFileName(commit plumbing.Hash) (string, error) {
 	return fmt.Sprintf("%s-%s.out", bb.String(), commit.String()), nil
 }
 
-func (b *Benchmarker) execBenchmark(ctx context.Context, pkgRoot string, commit plumbing.Hash) (out string, err error) {
+func (b *Benchmarker) exec(ctx context.Context, pkgRoot string, commit plumbing.Hash) (out string, err error) {
 	fileName, err := b.benchOutFileName(commit)
 	if err != nil {
 		return "", err

--- a/funcbench/main.go
+++ b/funcbench/main.go
@@ -218,7 +218,7 @@ func startBenchmark(
 
 	if compareWithItself {
 		bench.logger.Println("Assuming sub-benchmarks comparison.")
-		subResult, err := bench.execBenchmark(ctx, wt.Filesystem.Root(), ref.Hash())
+		subResult, err := bench.exec(ctx, wt.Filesystem.Root(), ref.Hash())
 		if err != nil {
 			return nil, errors.Wrap(err, "execute sub-benchmark")
 		}
@@ -233,7 +233,7 @@ func startBenchmark(
 	bench.logger.Println("Assuming comparing with target (clean workdir will be checked.)")
 
 	// Execute benchmark A.
-	newResult, err := bench.execBenchmark(ctx, wt.Filesystem.Root(), ref.Hash())
+	newResult, err := bench.exec(ctx, wt.Filesystem.Root(), ref.Hash())
 	if err != nil {
 		return nil, errors.Wrapf(err, "execute benchmark for A: %v", ref.Name().String())
 	}
@@ -254,7 +254,7 @@ func startBenchmark(
 	}
 
 	// Execute benchmark B.
-	oldResult, err := bench.execBenchmark(ctx, cmpWorkTreeDir, targetCommit)
+	oldResult, err := bench.exec(ctx, cmpWorkTreeDir, targetCommit)
 	if err != nil {
 		return nil, errors.Wrapf(err, "execute benchmark for B: %v", env.CompareTarget())
 	}


### PR DESCRIPTION
1. Use context to kill command, it finishes @bwplotka 's TODO
~2. Format the benchmark result, add PR number in the column header, see @geekodour 's comments in #350.~
