### PR TITLE
Adjust the format of the funcbench benchmark result

### DIFF
--- a/funcbench/env.go
+++ b/funcbench/env.go
@@ -138,7 +138,9 @@ func (g *GitHub) PostErr(ctx context.Context, err string) error {
 func (g *GitHub) PostResults(ctx context.Context, cmps []BenchCmp) error {
 	b := bytes.Buffer{}
 	Render(&b, cmps, false, false, g.compareTarget)
-	return g.client.postComment(ctx, formatCommentToMD(b.String()))
+	legend := fmt.Sprintf("Old: %s\nNew: PR-%d", g.compareTarget, g.client.prNumber)
+	result := fmt.Sprintf("<details><summary>Click to check benchmark result</summary>\n\n%s\n%s</details>", legend, formatCommentToMD(b.String()))
+	return g.client.postComment(ctx, result)
 }
 
 func (g *GitHub) Repo() *git.Repository { return g.repo }


### PR DESCRIPTION
This is a continuation of the work on `formatCommentToMD`.
The changes include:
1. A legend to result table.
2. A summary of benchmark result, [here](https://github.com/prometheus/test-infra/pull/355#issuecomment-623397733) suggested a collapsible feature we may use.

We can have more discussions here.
cc @geekodour 