### PR TITLE
Updated the k8s version to 1.16 for funcbench cluster

### DIFF
--- a/funcbench/manifests/cluster.yaml
+++ b/funcbench/manifests/cluster.yaml
@@ -2,7 +2,7 @@ projectid: {{ .PROJECT_ID }}
 zone: {{ .ZONE }}
 cluster:
   name: {{ .CLUSTER_NAME }}
-  initialclusterversion: 1.15
+  initialclusterversion: 1.16
   nodepools:
     - name: {{ .CLUSTER_NAME }}
       initialnodecount: 1


### PR DESCRIPTION
Running funcbench on k8s version 1.15 was showing [few network issues](https://github.com/prometheus/prometheus/pull/7287#issuecomment-636240590), upgrading to 1.16 fixes this. This issue does not show up with 1.14 either.

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>