### PR TITLE
Stop using shallow clone

### DIFF
--- a/funcbench/env.go
+++ b/funcbench/env.go
@@ -84,7 +84,6 @@ func newGitHubEnv(ctx context.Context, e environment, gc *gitHubClient, workspac
 	r, err := git.PlainCloneContext(ctx, fmt.Sprintf("%s/%s", workspace, gc.repo), false, &git.CloneOptions{
 		URL:      fmt.Sprintf("https://github.com/%s/%s.git", gc.owner, gc.repo),
 		Progress: os.Stdout,
-		Depth:    1,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "clone git repository")


### PR DESCRIPTION
This PR is to fix `object not found` error as in https://github.com/prometheus/prometheus/pull/7287#issuecomment-638212583.

It's exactly the same as reported [here](https://github.com/src-d/go-git/issues/1143#issuecomment-529676362).