### PR TITLE
Try to get target reference from either branch names or tags.

### DIFF
--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -46,11 +46,12 @@ Flags:
                              longer than duration d, panic.
 
 Args:
-  <target>              Can be one of '.', branch name or commit SHA of the
-                        branch to compare against. If set to '.', branch/commit
-                        is the same as the current one; funcbench will run once
-                        and try to compare between 2 sub-benchmarks. Errors out
-                        if there are no sub-benchmarks.
+  <target>              Can be one of '.', tag name, branch name or commit SHA
+                        of the branch to compare against. If set to '.',
+                        branch/commit is the same as the current one; funcbench
+                        will run once and try to compare between 2
+                        sub-benchmarks. Errors out if there are no
+                        sub-benchmarks.
   [<bench-func-regex>]  Function regex to use for benchmark.Supports RE2 regexp
                         and is fully anchored, by default will run all
                         benchmarks.

--- a/funcbench/main.go
+++ b/funcbench/main.go
@@ -231,7 +231,7 @@ func startBenchmark(
 	// Get info about target.
 	targetCommit := getTargetInfo(ctx, env.Repo(), env.CompareTarget())
 	if targetCommit == plumbing.ZeroHash {
-		return nil, fmt.Errorf("Cannot getTargetInfo from %s", env.CompareTarget())
+		return nil, fmt.Errorf("cannot find target %s", env.CompareTarget())
 	}
 
 	bench.logger.Println("Target:", targetCommit.String(), "Current Ref:", ref.Hash().String())
@@ -289,8 +289,8 @@ func interrupt(logger Logger, cancel <-chan struct{}) error {
 	}
 }
 
-// getTargetInfo returns the hash of the target,
-// if it cannot find from either branch names or tag names, plumbing.ZeroHash will return.
+// getTargetInfo returns the hash of the target if found,
+// otherwise returns plumbing.ZeroHash.
 func getTargetInfo(ctx context.Context, repo *git.Repository, target string) plumbing.Hash {
 	commitHash := plumbing.NewHash(target)
 	if !commitHash.IsZero() {

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	google.golang.org/grpc v1.19.0
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/src-d/go-git-fixtures.v3 v3.5.0
 	gopkg.in/src-d/go-git.v4 v4.13.1
 	gopkg.in/yaml.v2 v2.2.4
 	k8s.io/api v0.0.0-20190409021203-6e4e0e4f393b


### PR DESCRIPTION
This fix is for #373. Now a tag name like `v2.18.1` can be set as target to funcbench.