### PR TITLE
Remove whitespace and post command syntax issues

### DIFF
--- a/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
+++ b/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
@@ -20,6 +20,8 @@ spec:
         args:
         - "--eventmap=/etc/cm/eventmap.yml"
         - "--webhooksecretfile=/etc/github/whsecret"
+        - "--command-prefix=/prombench"
+        - "--command-prefix=/funcbench"
         name: comment-monitor
         env:
         - name: DOMAIN_NAME

--- a/tools/commentMonitor/README.md
+++ b/tools/commentMonitor/README.md
@@ -41,7 +41,7 @@ For example, the following regex will create an argument named `RELEASE` with th
 #### Usage and examples:
 [embedmd]:# (commentMonitor-flags.txt)
 ```txt
-usage: commentMonitor --command-prefixes=COMMAND-PREFIXES [<flags>]
+usage: commentMonitor [<flags>]
 
 commentMonitor GithubAction - Post and monitor GitHub comments.
 
@@ -54,9 +54,8 @@ Flags:
       --eventmap="./eventmap.yml"
                         Filepath to eventmap file.
       --port="8080"     port number to run webhook in.
-      --command-prefixes=COMMAND-PREFIXES
-                        Comma separated list of command prefixes.
-                        Eg."/prombench,/funcbench"
+      --command-prefix=COMMAND-PREFIX ...
+                        Specify allowed command prefix. Eg."/prombench"
 
 ```
 ### Building Docker Image

--- a/tools/commentMonitor/README.md
+++ b/tools/commentMonitor/README.md
@@ -5,7 +5,6 @@ Currently it only works with [`issue_comment` event](https://developer.github.co
 
 ### Environment Variables:
 - `LABEL_NAME`: If set, will add the label to the PR.
-- `COMMAND_PREFIXES`: Comma separated list of command prefixes.
 - `GITHUB_TOKEN` : GitHub oauth token used for posting comments and settings the label.
 - Any other environment variable used in any of the comment templates in `eventmap.yml`.
 
@@ -20,9 +19,6 @@ Example content of the `eventmap.yml` file:
   regex_string: (?mi)^/prombench\s+cancel\s*$
   comment_template: |
     Benchmark cancel is in progress.
-```
-```shell
-$ export COMMENT_PREFIX='/funcbench,/prombench'
 ```
 
 If a GitHub comment matches with `regex_string`, then commentMonitor will trigger a [`repository_dispatch`](https://developer.github.com/v3/repos/#create-a-repository-dispatch-event) with the event type `event_type` and then post a comment to the issue with `comment_template`. The extracted out arguments will be passed to the [`client_payload`](https://developer.github.com/v3/repos/#example-5) of the `repository_dispatch` event.
@@ -45,7 +41,7 @@ For example, the following regex will create an argument named `RELEASE` with th
 #### Usage and examples:
 [embedmd]:# (commentMonitor-flags.txt)
 ```txt
-usage: commentMonitor [<flags>]
+usage: commentMonitor --command-prefixes=COMMAND-PREFIXES [<flags>]
 
 commentMonitor GithubAction - Post and monitor GitHub comments.
 
@@ -58,6 +54,9 @@ Flags:
       --eventmap="./eventmap.yml"
                         Filepath to eventmap file.
       --port="8080"     port number to run webhook in.
+      --command-prefixes=COMMAND-PREFIXES
+                        Comma separated list of command prefixes.
+                        Eg."/prombench,/funcbench"
 
 ```
 ### Building Docker Image

--- a/tools/commentMonitor/README.md
+++ b/tools/commentMonitor/README.md
@@ -5,6 +5,7 @@ Currently it only works with [`issue_comment` event](https://developer.github.co
 
 ### Environment Variables:
 - `LABEL_NAME`: If set, will add the label to the PR.
+- `COMMAND_PREFIXES`: Comma separated list of command prefixes.
 - `GITHUB_TOKEN` : GitHub oauth token used for posting comments and settings the label.
 - Any other environment variable used in any of the comment templates in `eventmap.yml`.
 
@@ -14,11 +15,14 @@ Running commentMonitor requires the eventmap file which is specified by the `--e
 The `regex_string`, `event_type` and `comment_template` can be specified in the `eventmap.yml` file.
 
 Example content of the `eventmap.yml` file:
-```
+```yaml
 - event_type: prombench_stop
   regex_string: (?mi)^/prombench\s+cancel\s*$
   comment_template: |
     Benchmark cancel is in progress.
+```
+```shell
+$ export COMMENT_PREFIX='/funcbench,/prombench'
 ```
 
 If a GitHub comment matches with `regex_string`, then commentMonitor will trigger a [`repository_dispatch`](https://developer.github.com/v3/repos/#create-a-repository-dispatch-event) with the event type `event_type` and then post a comment to the issue with `comment_template`. The extracted out arguments will be passed to the [`client_payload`](https://developer.github.com/v3/repos/#example-5) of the `repository_dispatch` event.

--- a/tools/commentMonitor/client.go
+++ b/tools/commentMonitor/client.go
@@ -34,20 +34,6 @@ type commentMonitorClient struct {
 	commentTemplate string
 }
 
-// Check if the command starts with predefined prefix.
-func (c *commentMonitorClient) checkCommandPrefix(command string) bool {
-	if prefixes, ok := os.LookupEnv("COMMAND_PREFIXES"); ok {
-		prefixes := strings.Split(prefixes, ",")
-		for _, p := range prefixes {
-			i := strings.Index(command, p)
-			if i == 0 {
-				return true
-			}
-		}
-	}
-	return false
-}
-
 // Set eventType and commentTemplate if
 // regexString is validated against provided command.
 func (c *commentMonitorClient) validateRegex(command string) bool {
@@ -106,6 +92,7 @@ func (c *commentMonitorClient) extractArgs(ctx context.Context, command string) 
 			return fmt.Errorf("%v: could not fetch SHA", err)
 		}
 
+		// TODO (geekodour) : We could run this in a seperate method.
 		err = c.ghClient.createRepositoryDispatch(ctx, c.eventType, c.allArgs)
 		if err != nil {
 			return fmt.Errorf("%v: could not create repository_dispatch event", err)

--- a/tools/commentMonitor/client.go
+++ b/tools/commentMonitor/client.go
@@ -34,6 +34,29 @@ type commentMonitorClient struct {
 	commentTemplate string
 }
 
+func (c *commentMonitorClient) extractCommand() {
+	s := strings.TrimLeft(c.ghClient.commentBody, "\r\n\t ")
+	if i := strings.Index(s, "\n"); i != -1 {
+		s = s[:i]
+	}
+	s = strings.TrimRight(s, "\r\n\t ")
+	c.ghClient.commentBody = s
+}
+
+// Check if the command starts with predefined prefix.
+func (c *commentMonitorClient) checkCommandPrefix() bool {
+	if prefixes, ok := os.LookupEnv("COMMAND_PREFIXES"); ok {
+		prefixes := strings.Split(prefixes, ",")
+		for _, p := range prefixes {
+			i := strings.Index(c.ghClient.commentBody, p)
+			if i == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // Set eventType and commentTemplate if
 // regexString is validated against provided commentBody.
 func (c *commentMonitorClient) validateRegex() bool {

--- a/tools/commentMonitor/client.go
+++ b/tools/commentMonitor/client.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"bytes"
-	"context"
 	"fmt"
 	"log"
 	"os"
@@ -50,7 +49,7 @@ func (c *commentMonitorClient) validateRegex(command string) bool {
 }
 
 // Verify if user is allowed to perform activity.
-func (c commentMonitorClient) verifyUser(ctx context.Context, verifyUserDisabled bool) error {
+func (c commentMonitorClient) verifyUser(verifyUserDisabled bool) error {
 	if !verifyUserDisabled {
 		var allowed bool
 		allowedAssociations := []string{"COLLABORATOR", "MEMBER", "OWNER"}
@@ -61,7 +60,7 @@ func (c commentMonitorClient) verifyUser(ctx context.Context, verifyUserDisabled
 		}
 		if !allowed {
 			b := fmt.Sprintf("@%s is not a org member nor a collaborator and cannot execute benchmarks.", c.ghClient.author)
-			if err := c.ghClient.postComment(ctx, b); err != nil {
+			if err := c.ghClient.postComment(b); err != nil {
 				return fmt.Errorf("%v : couldn't post comment", err)
 			}
 			return fmt.Errorf("author is not a member or collaborator")
@@ -72,7 +71,7 @@ func (c commentMonitorClient) verifyUser(ctx context.Context, verifyUserDisabled
 }
 
 // Extract args if regexString provided.
-func (c *commentMonitorClient) extractArgs(ctx context.Context, command string) error {
+func (c *commentMonitorClient) extractArgs(command string) error {
 	var err error
 	if c.regex != nil {
 		// Add command arguments.
@@ -87,13 +86,13 @@ func (c *commentMonitorClient) extractArgs(ctx context.Context, command string) 
 
 		// Add non-comment arguments if any.
 		c.allArgs["PR_NUMBER"] = strconv.Itoa(c.ghClient.pr)
-		c.allArgs["LAST_COMMIT_SHA"], err = c.ghClient.getLastCommitSHA(ctx)
+		c.allArgs["LAST_COMMIT_SHA"], err = c.ghClient.getLastCommitSHA()
 		if err != nil {
 			return fmt.Errorf("%v: could not fetch SHA", err)
 		}
 
 		// TODO (geekodour) : We could run this in a seperate method.
-		err = c.ghClient.createRepositoryDispatch(ctx, c.eventType, c.allArgs)
+		err = c.ghClient.createRepositoryDispatch(c.eventType, c.allArgs)
 		if err != nil {
 			return fmt.Errorf("%v: could not create repository_dispatch event", err)
 		}
@@ -102,9 +101,9 @@ func (c *commentMonitorClient) extractArgs(ctx context.Context, command string) 
 }
 
 // Set label to Github pr if LABEL_NAME is set.
-func (c commentMonitorClient) postLabel(ctx context.Context) error {
+func (c commentMonitorClient) postLabel() error {
 	if os.Getenv("LABEL_NAME") != "" {
-		if err := c.ghClient.createLabel(ctx, os.Getenv("LABEL_NAME")); err != nil {
+		if err := c.ghClient.createLabel(os.Getenv("LABEL_NAME")); err != nil {
 			return fmt.Errorf("%v : couldn't set label", err)
 		}
 		log.Println("label successfully set")
@@ -112,7 +111,7 @@ func (c commentMonitorClient) postLabel(ctx context.Context) error {
 	return nil
 }
 
-func (c commentMonitorClient) generateAndPostComment(ctx context.Context) error {
+func (c commentMonitorClient) generateAndPostComment() error {
 	if c.commentTemplate != "" {
 		// Add all env vars to allArgs.
 		for _, e := range os.Environ() {
@@ -126,7 +125,7 @@ func (c commentMonitorClient) generateAndPostComment(ctx context.Context) error 
 			return err
 		}
 		// Post the comment.
-		if err := c.ghClient.postComment(ctx, buf.String()); err != nil {
+		if err := c.ghClient.postComment(buf.String()); err != nil {
 			return fmt.Errorf("%v : couldn't post generated comment", err)
 		}
 		log.Println("comment successfully posted")

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 
 	"github.com/google/go-github/v29/github"
-	"golang.org/x/oauth2"
 	"gopkg.in/alecthomas/kingpin.v2"
 	"gopkg.in/yaml.v2"
 )
@@ -69,24 +68,6 @@ func main() {
 	mux.HandleFunc("/", cmConfig.webhookExtract)
 	log.Println("Server is ready to handle requests at", cmConfig.port)
 	log.Fatal(http.ListenAndServe(fmt.Sprintf(":%v", cmConfig.port), mux))
-}
-
-func newGithubClient(ctx context.Context, e *github.IssueCommentEvent) (*githubClient, error) {
-	ghToken := os.Getenv("GITHUB_TOKEN")
-	if ghToken == "" {
-		return nil, fmt.Errorf("env var missing")
-	}
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: ghToken})
-	tc := oauth2.NewClient(ctx, ts)
-	return &githubClient{
-		clt:               github.NewClient(tc),
-		owner:             *e.GetRepo().Owner.Login,
-		repo:              *e.GetRepo().Name,
-		pr:                *e.GetIssue().Number,
-		author:            *e.Sender.Login,
-		authorAssociation: *e.GetComment().AuthorAssociation,
-		commentBody:       *e.GetComment().Body,
-	}, nil
 }
 
 func (c *commentMonitorConfig) loadConfig() error {

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -108,8 +108,7 @@ func extractCommand(s string) string {
 func checkCommandPrefix(command, prefixStrings string) bool {
 	prefixes := strings.Split(prefixStrings, ",")
 	for _, p := range prefixes {
-		i := strings.Index(command, p)
-		if i == 0 {
+		if strings.HasPrefix(command, p) {
 			return true
 		}
 	}
@@ -173,7 +172,7 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		// Validate regex.
 		if !cmClient.validateRegex(command) {
 			log.Println("invalid command syntax: ", command)
-			if err := cmClient.ghClient.postComment(ctx, "command syntax invalid"); err != nil {
+			if err := cmClient.ghClient.postComment("command syntax invalid"); err != nil {
 				log.Printf("%v : couldn't post comment", err)
 			}
 			http.Error(w, "command syntax invalid", http.StatusBadRequest)
@@ -181,7 +180,7 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		}
 
 		// Verify user.
-		err = cmClient.verifyUser(ctx, c.verifyUserDisabled)
+		err = cmClient.verifyUser(c.verifyUserDisabled)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, "user not allowed to run command", http.StatusForbidden)
@@ -189,7 +188,7 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		}
 
 		// Extract args.
-		err = cmClient.extractArgs(ctx, command)
+		err = cmClient.extractArgs(command)
 		if err != nil {
 			log.Println(err)
 			http.Error(w, "could not extract arguments", http.StatusBadRequest)
@@ -197,7 +196,7 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		}
 
 		// Post generated comment to GitHub pr.
-		err = cmClient.generateAndPostComment(ctx)
+		err = cmClient.generateAndPostComment()
 		if err != nil {
 			log.Println(err)
 			http.Error(w, "could not post comment to GitHub", http.StatusBadRequest)
@@ -205,7 +204,7 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		}
 
 		// Set label to GitHub pr.
-		err = cmClient.postLabel(ctx)
+		err = cmClient.postLabel()
 		if err != nil {
 			log.Println(err)
 			http.Error(w, "could not set label to GitHub", http.StatusBadRequest)

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -32,7 +32,7 @@ type commentMonitorConfig struct {
 	verifyUserDisabled bool
 	eventMapFilePath   string
 	whSecretFilePath   string
-	commandPrefixes    string
+	commandPrefixes    []string
 	whSecret           []byte
 	eventMap           webhookEventMaps
 	port               string
@@ -64,9 +64,8 @@ func main() {
 	app.Flag("port", "port number to run webhook in.").
 		Default("8080").
 		StringVar(&cmConfig.port)
-	app.Flag("command-prefixes", `Comma separated list of command prefixes. Eg."/prombench,/funcbench" `).
-		Required().
-		StringVar(&cmConfig.commandPrefixes)
+	app.Flag("command-prefix", `Specify allowed command prefix. Eg."/prombench" `).
+		StringsVar(&cmConfig.commandPrefixes)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	mux := http.NewServeMux()
@@ -105,8 +104,7 @@ func extractCommand(s string) string {
 	return s
 }
 
-func checkCommandPrefix(command, prefixStrings string) bool {
-	prefixes := strings.Split(prefixStrings, ",")
+func checkCommandPrefix(command string, prefixes []string) bool {
 	for _, p := range prefixes {
 		if strings.HasPrefix(command, p) {
 			return true

--- a/tools/commentMonitor/main_test.go
+++ b/tools/commentMonitor/main_test.go
@@ -35,7 +35,7 @@ func TestExtractCommand(t *testing.T) {
 	}
 }
 func TestCheckCommandPrefix(t *testing.T) {
-	prefixStrings := "/funcbench,/prombench,/somebench"
+	prefixes := []string{"/funcbench", "/prombench", "/somebench"}
 	testCases := []struct {
 		command string
 		valid   bool
@@ -47,7 +47,7 @@ func TestCheckCommandPrefix(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.command, func(t *testing.T) {
-			if checkCommandPrefix(tc.command, prefixStrings) != tc.valid {
+			if checkCommandPrefix(tc.command, prefixes) != tc.valid {
 				t.Errorf("want %v, got %v", tc.valid, !tc.valid)
 			}
 		})

--- a/tools/commentMonitor/main_test.go
+++ b/tools/commentMonitor/main_test.go
@@ -1,0 +1,55 @@
+// Copyright 2020 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "testing"
+
+func TestExtractCommand(t *testing.T) {
+	testCases := []struct {
+		commentBody string
+		command     string
+	}{
+		{"\r\n/funcbench master\t", "/funcbench master"},
+		{"\r\n/funcbench master\n", "/funcbench master"},
+		{"\r\n/funcbench master\r\n", "/funcbench master"},
+		{"/prombench master\r\n", "/prombench master"},
+		{"/funcbench master .*\t\r\nSomething", "/funcbench master .*"},
+		{"command without forwardslash", "command without forwardslash"},
+	}
+	for _, tc := range testCases {
+		command := extractCommand(tc.commentBody)
+		if command != tc.command {
+			t.Errorf("want %s, got %s", tc.command, command)
+		}
+	}
+}
+func TestCheckCommandPrefix(t *testing.T) {
+	prefixStrings := "/funcbench,/prombench,/somebench"
+	testCases := []struct {
+		command string
+		valid   bool
+	}{
+		{"/funcbench master", true},
+		{"/somebench master", true},
+		{"/querybench master", false},
+		{"prombench master", false},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.command, func(t *testing.T) {
+			if checkCommandPrefix(tc.command, prefixStrings) != tc.valid {
+				t.Errorf("want %v, got %v", tc.valid, !tc.valid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Added `extractCommand` to trim whitespaces
* Added `checkCommandPrefix` to check if it's a test-infra command and later
post a github comment in the PR if regex is not valid for the command.
* ~Added `COMMAND_PREFIXES` environment variable for specifying the command prefixes.~
* Added `--command-prefixes` flag for specifying the command prefixes.


Fixes: #375 

cc: @krasi-georgiev @nevill 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>