### PR TITLE
Fix embedmd syntax issue and update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ docker-manifest:
 	@echo skip manifest creation
 
 .PHONY: docs
-docs: build
+docs:
 	./scripts/genflagdocs.sh
 
 .PHONY: docs-check

--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -12,8 +12,7 @@ funcbench currently supports two modes, Local and GitHub. Running it in the Gith
 
 > Clean git state is required.
 
-[embedmd]: # "funcbench-flags.txt"
-
+[embedmd]:# (funcbench-flags.txt)
 ```txt
 usage: funcbench [<flags>] <target> [<bench-func-regex>]
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,8 +10,7 @@ Eg. `somefile.yaml` will be parsed, whereas `somefile_noparse.yaml` will not be 
 
 ## Usage and examples:
 
-[embedmd]: # "./infra-flags.txt"
-
+[embedmd]:# (infra-flags.txt)
 ```txt
 usage: infra [<flags>] <command> [<args> ...]
 

--- a/scripts/genflagdocs.sh
+++ b/scripts/genflagdocs.sh
@@ -24,7 +24,7 @@ if [[ "${CHECK}" == "check" ]]; then
     RESULT=$?
     if [[ "$RESULT" != "0" ]]; then
         cat << EOF
-Docs have discrepancies, do 'make docs' and commit changes:
+Docs have discrepancies, do 'make build docs' and commit changes:
 
 ${DIFF}
 EOF


### PR DESCRIPTION
`make docs-check` was not running as expected for few README files as the syntax was modified in some earlier PR.

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>