### PR TITLE
Use vendoring and post go test command to Github comment

### DIFF
--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -33,9 +33,8 @@ import (
 type Benchmarker struct {
 	logger Logger
 
+	benchmarkArgs  []string
 	benchFunc      string
-	benchTime      time.Duration
-	benchTimeout   time.Duration
 	resultCacheDir string
 
 	c    *commander
@@ -44,10 +43,20 @@ type Benchmarker struct {
 
 func newBenchmarker(logger Logger, env Environment, c *commander, benchTime time.Duration, benchTimeout time.Duration, resultCacheDir string) *Benchmarker {
 	return &Benchmarker{
-		logger:         logger,
-		benchFunc:      env.BenchFunc(),
-		benchTime:      benchTime,
-		benchTimeout:   benchTimeout,
+		logger:    logger,
+		benchFunc: env.BenchFunc(),
+		benchmarkArgs: []string{
+			// TODO(bwplotka): Allow memprofiles.
+			// 'go test' flags: https://golang.org/cmd/go/#hdr-Testing_flags
+			"go test",
+			"-mod", "vendor",
+			"-run", "^$",
+			"-bench", fmt.Sprintf("^%s$", env.BenchFunc()),
+			"-benchmem",
+			"-benchtime", benchTime.String(),
+			"-timeout", benchTimeout.String(),
+			"./...",
+		},
 		c:              c,
 		repo:           env.Repo(),
 		resultCacheDir: resultCacheDir,
@@ -79,19 +88,7 @@ func (b *Benchmarker) exec(ctx context.Context, pkgRoot string, commit plumbing.
 		return filepath.Join(b.resultCacheDir, fileName), nil
 	}
 
-	// TODO(bwplotka): Allow memprofiles.
-	// 'go test' flags: https://golang.org/cmd/go/#hdr-Testing_flags
-	extraArgs := []string{
-		"go test",
-		"-mod", "vendor",
-		"-run", "^$",
-		"-bench", fmt.Sprintf("^%s$", b.benchFunc),
-		"-benchmem",
-		"-benchtime", b.benchTime.String(),
-		"-timeout", b.benchTimeout.String(),
-		"./...",
-	}
-	benchCmd := []string{"sh", "-c", strings.Join(append([]string{"cd", pkgRoot, "&&"}, extraArgs...), " ")}
+	benchCmd := []string{"sh", "-c", strings.Join(append([]string{"cd", pkgRoot, "&&"}, b.benchmarkArgs...), " ")}
 
 	b.logger.Println("Executing benchmark command for", commit.String(), "\n", benchCmd)
 	out, err = b.c.exec(ctx, benchCmd...)

--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -81,9 +81,17 @@ func (b *Benchmarker) exec(ctx context.Context, pkgRoot string, commit plumbing.
 
 	// TODO(bwplotka): Allow memprofiles.
 	// 'go test' flags: https://golang.org/cmd/go/#hdr-Testing_flags
-	extraArgs := []string{"-benchtime", b.benchTime.String()}
-	extraArgs = append(extraArgs, "-timeout", b.benchTimeout.String())
-	benchCmd := []string{"sh", "-c", strings.Join(append(append([]string{"cd", pkgRoot, "&&", "go", "test", "-run", "^$", "-bench", fmt.Sprintf("^%s$", b.benchFunc), "-benchmem"}, extraArgs...), "./..."), " ")}
+	extraArgs := []string{
+		"go test",
+		"-mod", "vendor",
+		"-run", "^$",
+		"-bench", fmt.Sprintf("^%s$", b.benchFunc),
+		"-benchmem",
+		"-benchtime", b.benchTime.String(),
+		"-timeout", b.benchTimeout.String(),
+		"./...",
+	}
+	benchCmd := []string{"sh", "-c", strings.Join(append([]string{"cd", pkgRoot, "&&"}, extraArgs...), " ")}
 
 	b.logger.Println("Executing benchmark command for", commit.String(), "\n", benchCmd)
 	out, err = b.c.exec(ctx, benchCmd...)

--- a/funcbench/env.go
+++ b/funcbench/env.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/go-github/v29/github"
 	"github.com/pkg/errors"
@@ -32,7 +33,7 @@ type Environment interface {
 	CompareTarget() string
 
 	PostErr(ctx context.Context, err string) error
-	PostResults(ctx context.Context, cmps []BenchCmp) error
+	PostResults(ctx context.Context, cmps []BenchCmp, extraInfo ...string) error
 
 	Repo() *git.Repository
 }
@@ -64,7 +65,7 @@ func newLocalEnv(e environment) (Environment, error) {
 
 func (l *Local) PostErr(context.Context, string) error { return nil } // Noop. We will see error anyway.
 
-func (l *Local) PostResults(ctx context.Context, cmps []BenchCmp) error {
+func (l *Local) PostResults(ctx context.Context, cmps []BenchCmp, extraInfo ...string) error {
 	fmt.Println("Results:")
 	Render(os.Stdout, cmps, false, false, l.compareTarget)
 	return nil
@@ -134,11 +135,11 @@ func (g *GitHub) PostErr(ctx context.Context, err string) error {
 	return nil
 }
 
-func (g *GitHub) PostResults(ctx context.Context, cmps []BenchCmp) error {
+func (g *GitHub) PostResults(ctx context.Context, cmps []BenchCmp, extraInfo ...string) error {
 	b := bytes.Buffer{}
 	Render(&b, cmps, false, false, g.compareTarget)
-	legend := fmt.Sprintf("Old: %s\nNew: PR-%d", g.compareTarget, g.client.prNumber)
-	result := fmt.Sprintf("<details><summary>Click to check benchmark result</summary>\n\n%s\n%s</details>", legend, formatCommentToMD(b.String()))
+	legend := fmt.Sprintf("Old: `%s`\nNew: `PR-%d`", g.compareTarget, g.client.prNumber)
+	result := fmt.Sprintf("<details><summary>Click to check benchmark result</summary>\n\n%s\n%s\n%s</details>", legend, strings.Join(extraInfo, "\n"), formatCommentToMD(b.String()))
 	return g.client.postComment(ctx, result)
 }
 


### PR DESCRIPTION
- Added `mod=vendor` when running test
- Post command run to the github comment that funcbench makes with its results.

Example Comment (https://github.com/prometheus-community/prometheus/pull/67#issuecomment-645435128)

cc: @krasi-georgiev @nevill 