### PR TITLE
Added k8s secret for GITHUB_TOKEN.

### DIFF
--- a/funcbench/Makefile
+++ b/funcbench/Makefile
@@ -32,4 +32,5 @@ resource_delete:
 		-v GITHUB_ORG:${GITHUB_ORG} -v GITHUB_REPO:${GITHUB_REPO} \
 		-v BRANCH:${BRANCH} -v BENCH_FUNC_REGEX:${BENCH_FUNC_REGEX} \
 		-f manifests/benchmark/3_job.yaml \
+		-f manifests/benchmark/2_secrets.yaml \
 		-f manifests/benchmark/1_namespace.yaml

--- a/funcbench/Makefile
+++ b/funcbench/Makefile
@@ -28,8 +28,8 @@ resource_apply:
 resource_delete:
 	$(INFRA_CMD) gke resource delete -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v PROJECT_ID:${PROJECT_ID} -v CLUSTER_NAME:funcbench-${PR_NUMBER} \
-		-v PR_NUMBER:${PR_NUMBER} -v GITHUB_TOKEN:${GITHUB_TOKEN} \
+		-v PR_NUMBER:${PR_NUMBER} \
 		-v GITHUB_ORG:${GITHUB_ORG} -v GITHUB_REPO:${GITHUB_REPO} \
 		-v BRANCH:${BRANCH} -v BENCH_FUNC_REGEX:${BENCH_FUNC_REGEX} \
-		-f manifests/benchmark/2_job.yaml \
+		-f manifests/benchmark/3_job.yaml \
 		-f manifests/benchmark/1_namespace.yaml

--- a/funcbench/manifests/benchmark/2_secrets.yaml
+++ b/funcbench/manifests/benchmark/2_secrets.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-token
+  namespace: funcbench-{{ .PR_NUMBER }}
+type: Opaque
+stringData:
+  token: "{{ .GITHUB_TOKEN }}"

--- a/funcbench/manifests/benchmark/3_job.yaml
+++ b/funcbench/manifests/benchmark/3_job.yaml
@@ -25,6 +25,9 @@ spec:
           - "{{ .BENCH_FUNC_REGEX }}"
         env:
           - name: GITHUB_TOKEN
-            value: "{{ .GITHUB_TOKEN }}"
+            valueFrom:
+              secretKeyRef:
+                name: github-token
+                key: token
       nodeSelector:
         node-name: funcbench-{{ .PR_NUMBER }}


### PR DESCRIPTION
Currently token is being passed as is:
https://github.com/prometheus/test-infra/blob/6f26e55f5899716114ac83d4d106b7b01edef4b8/funcbench/manifests/benchmark/2_job.yaml#L28

This PR creates a k8s secret and sets that to the appropriate env var.

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>