### PR TITLE
Add support for help text and minor fixes for comment-monitor

### DIFF
--- a/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
+++ b/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
@@ -1,59 +1,67 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: comment-monitor-eventmap
+  name: comment-monitor-config
 data:
-  eventmap.yml: |
-    - event_type: prombench_start
-      regex_string: (?mi)^/prombench\s*(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$
-      label: prombench
-      comment_template: |
-        ⏱️ Welcome to Prometheus Benchmarking Tool. ⏱️
+  config.yml: |
+    prefixes:
+      - prefix: /prombench
+        help_template: |
+          Incorrect prombench syntax, please find [correct syntax here](https://github.com/prometheus/test-infra/tree/master/prombench#trigger-tests-via-a-github-comment).
+      - prefix: /funcbench
+        help_template: |
+          Incorrect funcbench syntax, please find [correct syntax here](https://github.com/prometheus/test-infra/tree/master/funcbench#triggering-with-github-comments).
+    events:
+      - event_type: prombench_start
+        regex_string: (?mi)^/prombench\s*(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$
+        label: prombench
+        comment_template: |
+          ⏱️ Welcome to Prometheus Benchmarking Tool. ⏱️
 
-        **Compared versions:** [**`PR-{{ index . "PR_NUMBER" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-pr) and [**`{{ index . "RELEASE" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-release)
+          **Compared versions:** [**`PR-{{ index . "PR_NUMBER" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-pr) and [**`{{ index . "RELEASE" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-release)
 
-        After successful deployment, the benchmarking metrics can be viewed at:
+          After successful deployment, the benchmarking metrics can be viewed at:
 
-        - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
-        - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number={{ index . "PR_NUMBER" }})
-        - [Grafana Explorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
+          - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
+          - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number={{ index . "PR_NUMBER" }})
+          - [Grafana Explorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
 
-        **Other Commands:**
-        To stop benchmark: `/prombench cancel`
-        To restart benchmark: `/prombench restart {{ index . "RELEASE" }}`
+          **Other Commands:**
+          To stop benchmark: `/prombench cancel`
+          To restart benchmark: `/prombench restart {{ index . "RELEASE" }}`
 
-    - event_type: prombench_stop
-      regex_string: (?mi)^/prombench\s+cancel\s*$
-      comment_template: |
-        Benchmark cancel is in progress.
+      - event_type: prombench_stop
+        regex_string: (?mi)^/prombench\s+cancel\s*$
+        comment_template: |
+          Benchmark cancel is in progress.
 
-    - event_type: noop
-      regex_string: (?mi)^/prombench\s*$
-      comment_template: |
-        Please add the version number to compare against.
-        Eg. `/prombench master`, `/prombench v2.12.0`
+      - event_type: noop
+        regex_string: (?mi)^/prombench\s*$
+        comment_template: |
+          Please add the version number to compare against.
+          Eg. `/prombench master`, `/prombench v2.12.0`
 
-    - event_type: prombench_restart
-      regex_string: (?mi)^/prombench\s+restart\s+(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$
-      comment_template: |
-        ⏱️ Welcome to Prometheus Benchmarking Tool. ⏱️
+      - event_type: prombench_restart
+        regex_string: (?mi)^/prombench\s+restart\s+(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$
+        comment_template: |
+          ⏱️ Welcome to Prometheus Benchmarking Tool. ⏱️
 
-        **Compared versions:** [**`PR-{{ index . "PR_NUMBER" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-pr) and [**`{{ index . "RELEASE" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-release)
+          **Compared versions:** [**`PR-{{ index . "PR_NUMBER" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-pr) and [**`{{ index . "RELEASE" }}`**](http://{{ index . "DOMAIN_NAME" }}/{{ index . "PR_NUMBER" }}/prometheus-release)
 
-        After successful deployment, the benchmarking metrics can be viewed at:
+          After successful deployment, the benchmarking metrics can be viewed at:
 
-        - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
-        - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number={{ index . "PR_NUMBER" }})
-        - [Grafana Exlorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
+          - [Prometheus Meta](http://{{ index . "DOMAIN_NAME" }}/prometheus-meta/graph?g0.expr={namespace%3D"prombench-{{ index . "PR_NUMBER" }}"}&g0.tab=1)
+          - [Prombench Dashboard](http://{{ index . "DOMAIN_NAME" }}/grafana/d/7gmLoNDmz/prombench?orgId=1&var-pr-number={{ index . "PR_NUMBER" }})
+          - [Grafana Exlorer, Loki logs](http://{{ index . "DOMAIN_NAME" }}/grafana/explore?orgId=1&left=["now-6h","now","loki-meta",{},{"mode":"Logs"},{"ui":[true,true,true,"none"]}])
 
-        **Other Commands:**
-        To stop benchmark: `/prombench cancel`
-        To restart benchmark: `/prombench restart {{ index . "RELEASE" }}`
+          **Other Commands:**
+          To stop benchmark: `/prombench cancel`
+          To restart benchmark: `/prombench restart {{ index . "RELEASE" }}`
 
-    - event_type: funcbench_start
-      regex_string: (?m)^/funcbench[[:blank:]]+(?P<BRANCH>[\w\-\/\.]+)[[:blank:]]*(?P<BENCH_FUNC_REGEX>(?:Benchmark\w*)?(?:\.\*)?)?[[:blank:]]*$
-      label: funcbench
-      comment_template: |
-        ⏱️ Welcome to Funcbench Tool. ⏱️
+      - event_type: funcbench_start
+        regex_string: (?m)^/funcbench[[:blank:]]+(?P<BRANCH>[\w\-\/\.]+)[[:blank:]]*(?P<BENCH_FUNC_REGEX>(?:Benchmark\w*)?(?:\.\*)?)?[[:blank:]]*$
+        label: funcbench
+        comment_template: |
+          ⏱️ Welcome to Funcbench Tool. ⏱️
 
-        Running benchmark `{{ index . "BENCH_FUNC_REGEX"}}` on **`PR-{{ index . "PR_NUMBER" }}`** vs **`{{ index . "BRANCH" }}`**
+          Running benchmark `{{ index . "BENCH_FUNC_REGEX"}}` on **`PR-{{ index . "PR_NUMBER" }}`** vs **`{{ index . "BRANCH" }}`**

--- a/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
+++ b/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
@@ -18,10 +18,8 @@ spec:
       - image: docker.io/prominfra/comment-monitor:master
         imagePullPolicy: Always
         args:
-        - "--eventmap=/etc/cm/eventmap.yml"
+        - "--config=/etc/cm/config.yml"
         - "--webhooksecretfile=/etc/github/whsecret"
-        - "--command-prefix=/prombench"
-        - "--command-prefix=/funcbench"
         name: comment-monitor
         env:
         - name: DOMAIN_NAME
@@ -35,7 +33,7 @@ spec:
         - name: whsecret
           mountPath: /etc/github
           readOnly: true
-        - name: comment-monitor-eventmap
+        - name: comment-monitor-config
           mountPath: /etc/cm/
         ports:
         - name: cm-port
@@ -44,9 +42,9 @@ spec:
       - name: whsecret
         secret:
           secretName: whsecret
-      - name: comment-monitor-eventmap
+      - name: comment-monitor-config
         configMap:
-          name: comment-monitor-eventmap
+          name: comment-monitor-config
       terminationGracePeriodSeconds: 300
       nodeSelector:
         node-name: main-node

--- a/tools/commentMonitor/README.md
+++ b/tools/commentMonitor/README.md
@@ -5,31 +5,38 @@ Currently it only works with [`issue_comment` event](https://developer.github.co
 
 ### Environment Variables:
 - `GITHUB_TOKEN` : GitHub oauth token used for posting comments and settings the label.
-- Any other environment variable used in any of the comment templates in `eventmap.yml`.
+- Any other environment variable used in any of the comment templates in `config.yml`.
 
 ### Setting up the webhook server
-Running commentMonitor requires the eventmap file which is specified by the `--eventmap` flag.
+To specify the config file for commentMonitor use the the `--config` flag.
 
-The `regex_string`, `event_type` and `comment_template` can be specified in the `eventmap.yml` file.
-
-Example content of the `eventmap.yml` file:
+Example `config.yml` file:
 ```yaml
-- event_type: prombench_stop
-  regex_string: (?mi)^/prombench\s+cancel\s*$
-  comment_template: |
-    Benchmark cancel is in progress.
-  label: prombench
+prefixes:
+  - prefix: /prombench
+    help_template: |
+      Get prombench syntax help here.
+  - prefix: /funcbench
+    help_template: |
+      Get funcbench syntax help [here](https://canbealink).
+eventmaps:
+  - event_type: prombench_stop
+    regex_string: (?mi)^/prombench\s+cancel\s*$
+    comment_template: |
+      Benchmark cancel is in progress.
+    label: prombench
 ```
 
-If a GitHub comment matches with `regex_string`, then commentMonitor will trigger a [`repository_dispatch`](https://developer.github.com/v3/repos/#create-a-repository-dispatch-event) with the event type `event_type` and then post a comment to the issue with `comment_template`. The extracted out arguments will be passed to the [`client_payload`](https://developer.github.com/v3/repos/#example-5) of the `repository_dispatch` event.
+Before comments are matched against `regex_string`, they are checked if they start with any of the prefixes mentioned in `prefixes`. If not, the request is simply dropped.  Once a comment matches with `regex_string`, commentMonitor will trigger a [`repository_dispatch` event](https://developer.github.com/v3/repos/#create-a-repository-dispatch-event) with the event type `event_type` and then post a comment to the issue/pr with `comment_template`. The extracted out arguments will be passed to the [`client_payload`](https://developer.github.com/v3/repos/#example-5) of the `repository_dispatch` event.
 
+If the matching with `regex_string` fails, then a comment with the `help_template` for that template is posted back to the corresponding issue/pr.
 
 ### Setting up the GitHub webhook
 - Create a personal access token with the scope `public_repo` and `write:discussion` and set the environment variable `GITHUB_TOKEN` with it.
 - Set the webhook server URL as the webhook URL in the repository settings and set the content type to `application/json`.
 
 ## Extracting arguments
-The `regex_string` provided in `eventmap.yml` is used to parse the comment into separate arguments. Additionally, some internal args are automatically set, eg. `PR_NUMBER` and `LAST_COMMMIT_SHA`.
+The `regex_string` provided in `config.yml` is used to parse the comment into separate arguments. Additionally, some internal args are automatically set, eg. `PR_NUMBER` and `LAST_COMMMIT_SHA`.
 
 If `regex_string` contains a capturing groups, using [named groups](https://godoc.org/regexp/syntax) is mandatory so that each comment argument is named after the regex group.
 
@@ -46,16 +53,13 @@ usage: commentMonitor [<flags>]
 commentMonitor GithubAction - Post and monitor GitHub comments.
 
 Flags:
-  -h, --help            Show context-sensitive help (also try --help-long and
-                        --help-man).
+  -h, --help                   Show context-sensitive help (also try --help-long
+                               and --help-man).
       --webhooksecretfile="./whsecret"
-                        path to webhook secret file
-      --no-verify-user  disable verifying user
-      --eventmap="./eventmap.yml"
-                        Filepath to eventmap file.
-      --port="8080"     port number to run webhook in.
-      --command-prefix=COMMAND-PREFIX ...
-                        Specify allowed command prefix. Eg."/prombench"
+                               path to webhook secret file
+      --no-verify-user         disable verifying user
+      --config="./config.yml"  Filepath to config file.
+      --port="8080"            port number to run webhook in.
 
 ```
 ### Building Docker Image

--- a/tools/commentMonitor/README.md
+++ b/tools/commentMonitor/README.md
@@ -29,7 +29,7 @@ eventmaps:
 
 Before comments are matched against `regex_string`, they are checked if they start with any of the prefixes mentioned in `prefixes`. If not, the request is simply dropped.  Once a comment matches with `regex_string`, commentMonitor will trigger a [`repository_dispatch` event](https://developer.github.com/v3/repos/#create-a-repository-dispatch-event) with the event type `event_type` and then post a comment to the issue/pr with `comment_template`. The extracted out arguments will be passed to the [`client_payload`](https://developer.github.com/v3/repos/#example-5) of the `repository_dispatch` event.
 
-If the matching with `regex_string` fails, then a comment with the `help_template` for that template is posted back to the corresponding issue/pr.
+If the matching with `regex_string` fails, then a comment with the `help_template` for that prefix is posted back to the corresponding issue/pr.
 
 ### Setting up the GitHub webhook
 - Create a personal access token with the scope `public_repo` and `write:discussion` and set the environment variable `GITHUB_TOKEN` with it.

--- a/tools/commentMonitor/client.go
+++ b/tools/commentMonitor/client.go
@@ -28,7 +28,7 @@ type commentMonitorClient struct {
 	ghClient           *githubClient
 	allArgs            map[string]string
 	regex              *regexp.Regexp
-	eventMap           []webhookEventMap
+	events             []webhookEvent
 	prefixes           []commandPrefix
 	prefixHelpTemplate string
 	eventType          string
@@ -39,7 +39,7 @@ type commentMonitorClient struct {
 // Set eventType and commentTemplate if
 // regexString is validated against provided command.
 func (c *commentMonitorClient) validateRegex(command string) bool {
-	for _, e := range c.eventMap {
+	for _, e := range c.events {
 		c.regex = regexp.MustCompile(e.RegexString)
 		if c.regex.MatchString(command) {
 			c.commentTemplate = e.CommentTemplate

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -30,15 +30,18 @@ import (
 
 type commentMonitorConfig struct {
 	verifyUserDisabled bool
-	eventMapFilePath   string
+	configFilePath     string
 	whSecretFilePath   string
-	commandPrefixes    []string
 	whSecret           []byte
-	eventMap           webhookEventMaps
+	configFile         configFile
 	port               string
 }
 
-// Structure of eventmap.yml file.
+type commandPrefix struct {
+	Prefix       string `yaml:"prefix"`
+	HelpTemplate string `yaml:"help_template"`
+}
+
 type webhookEventMap struct {
 	EventType       string `yaml:"event_type"`
 	CommentTemplate string `yaml:"comment_template"`
@@ -46,7 +49,10 @@ type webhookEventMap struct {
 	Label           string `yaml:"label"`
 }
 
-type webhookEventMaps []webhookEventMap
+type configFile struct {
+	Prefixes         []commandPrefix   `yaml:"prefixes"`
+	WebhookEventMaps []webhookEventMap `yaml:"eventmaps"`
+}
 
 func main() {
 	log.SetFlags(log.Ltime | log.Lshortfile)
@@ -59,14 +65,12 @@ func main() {
 		StringVar(&cmConfig.whSecretFilePath)
 	app.Flag("no-verify-user", "disable verifying user").
 		BoolVar(&cmConfig.verifyUserDisabled)
-	app.Flag("eventmap", "Filepath to eventmap file.").
-		Default("./eventmap.yml").
-		StringVar(&cmConfig.eventMapFilePath)
+	app.Flag("config", "Filepath to config file.").
+		Default("./config.yml").
+		StringVar(&cmConfig.configFilePath)
 	app.Flag("port", "port number to run webhook in.").
 		Default("8080").
 		StringVar(&cmConfig.port)
-	app.Flag("command-prefix", `Specify allowed command prefix. Eg."/prombench" `).
-		StringsVar(&cmConfig.commandPrefixes)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	mux := http.NewServeMux()
@@ -76,17 +80,17 @@ func main() {
 }
 
 func (c *commentMonitorConfig) loadConfig() error {
-	// Get eventmap file.
-	data, err := ioutil.ReadFile(c.eventMapFilePath)
+	// Get config file.
+	data, err := ioutil.ReadFile(c.configFilePath)
 	if err != nil {
 		return err
 	}
-	err = yaml.UnmarshalStrict(data, &c.eventMap)
+	err = yaml.UnmarshalStrict(data, &c.configFile)
 	if err != nil {
 		return fmt.Errorf("cannot unmarshal data: %v", err)
 	}
-	if len(c.eventMap) == 0 {
-		return fmt.Errorf("eventmap empty")
+	if len(c.configFile.WebhookEventMaps) == 0 || len(c.configFile.Prefixes) == 0 {
+		return fmt.Errorf("empty eventmap or prefix list")
 	}
 	// Get webhook secret.
 	c.whSecret, err = ioutil.ReadFile(c.whSecretFilePath)
@@ -103,15 +107,6 @@ func extractCommand(s string) string {
 	}
 	s = strings.TrimRight(s, "\r\n\t ")
 	return s
-}
-
-func checkCommandPrefix(command string, prefixes []string) bool {
-	for _, p := range prefixes {
-		if strings.HasPrefix(command, p) {
-			return true
-		}
-	}
-	return false
 }
 
 func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Request) {
@@ -136,7 +131,8 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 	// Setup commentMonitor client.
 	cmClient := commentMonitorClient{
 		allArgs:  make(map[string]string),
-		eventMap: c.eventMap,
+		eventMap: c.configFile.WebhookEventMaps,
+		prefixes: c.configFile.Prefixes,
 	}
 
 	// Parse webhook event.
@@ -167,8 +163,8 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		// Strip whitespace.
 		command := extractCommand(cmClient.ghClient.commentBody)
 
-		// test-infra command check.
-		if !checkCommandPrefix(command, c.commandPrefixes) {
+		// Command check.
+		if !cmClient.checkCommandPrefix(command) {
 			http.Error(w, "comment validation failed", http.StatusOK)
 			return
 		}
@@ -176,8 +172,11 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		// Validate regex.
 		if !cmClient.validateRegex(command) {
 			log.Println("invalid command syntax: ", command)
-			if err := cmClient.ghClient.postComment("command syntax invalid"); err != nil {
-				log.Printf("%v : couldn't post comment", err)
+			err = cmClient.generateAndPostErrorComment()
+			if err != nil {
+				log.Println(err)
+				http.Error(w, "could not post comment to GitHub", http.StatusBadRequest)
+				return
 			}
 			http.Error(w, "command syntax invalid", http.StatusBadRequest)
 			return
@@ -200,7 +199,7 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		}
 
 		// Post generated comment to GitHub pr.
-		err = cmClient.generateAndPostComment()
+		err = cmClient.generateAndPostSuccessComment()
 		if err != nil {
 			log.Println(err)
 			http.Error(w, "could not post comment to GitHub", http.StatusBadRequest)

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -150,6 +150,11 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 	switch e := event.(type) {
 	case *github.IssueCommentEvent:
 
+		if *e.Action != "created" {
+			http.Error(w, "issue_comment type must be 'created'", http.StatusOK)
+			return
+		}
+
 		// Setup github client.
 		ctx := context.Background()
 		cmClient.ghClient, err = newGithubClient(ctx, e)

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -42,7 +42,7 @@ type commandPrefix struct {
 	HelpTemplate string `yaml:"help_template"`
 }
 
-type webhookEventMap struct {
+type webhookEvent struct {
 	EventType       string `yaml:"event_type"`
 	CommentTemplate string `yaml:"comment_template"`
 	RegexString     string `yaml:"regex_string"`
@@ -50,8 +50,8 @@ type webhookEventMap struct {
 }
 
 type configFile struct {
-	Prefixes         []commandPrefix   `yaml:"prefixes"`
-	WebhookEventMaps []webhookEventMap `yaml:"eventmaps"`
+	Prefixes      []commandPrefix `yaml:"prefixes"`
+	WebhookEvents []webhookEvent  `yaml:"events"`
 }
 
 func main() {
@@ -89,7 +89,7 @@ func (c *commentMonitorConfig) loadConfig() error {
 	if err != nil {
 		return fmt.Errorf("cannot unmarshal data: %v", err)
 	}
-	if len(c.configFile.WebhookEventMaps) == 0 || len(c.configFile.Prefixes) == 0 {
+	if len(c.configFile.WebhookEvents) == 0 || len(c.configFile.Prefixes) == 0 {
 		return fmt.Errorf("empty eventmap or prefix list")
 	}
 	// Get webhook secret.
@@ -131,7 +131,7 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 	// Setup commentMonitor client.
 	cmClient := commentMonitorClient{
 		allArgs:  make(map[string]string),
-		eventMap: c.configFile.WebhookEventMaps,
+		events:   c.configFile.WebhookEvents,
 		prefixes: c.configFile.Prefixes,
 	}
 

--- a/tools/commentMonitor/main_test.go
+++ b/tools/commentMonitor/main_test.go
@@ -35,7 +35,13 @@ func TestExtractCommand(t *testing.T) {
 	}
 }
 func TestCheckCommandPrefix(t *testing.T) {
-	prefixes := []string{"/funcbench", "/prombench", "/somebench"}
+	cmClient := commentMonitorClient{
+		prefixes: []commandPrefix{
+			{"/funcbench", "help"},
+			{"/prombench", "help"},
+			{"/somebench", "help"},
+		},
+	}
 	testCases := []struct {
 		command string
 		valid   bool
@@ -47,7 +53,7 @@ func TestCheckCommandPrefix(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.command, func(t *testing.T) {
-			if checkCommandPrefix(tc.command, prefixes) != tc.valid {
+			if cmClient.checkCommandPrefix(tc.command) != tc.valid {
 				t.Errorf("want %v, got %v", tc.valid, !tc.valid)
 			}
 		})


### PR DESCRIPTION
Fixes #394 and #397 

* Removed `--command-prefix` flag, by adding `prefixes` to `config.yml`
* `config.yml` which replaces `eventmap.yml`
* Added help text for each prefix from the config.yml file (#397)
* `repository_dispatch` event dispatch sent only on creation of `issue_comment` event (#394 )

Todo:
- [x] Update the manifest file

cc :  @krasi-georgiev @nevill 