### PR TITLE
Removing unused service-account secret from 1b_secret

### DIFF
--- a/prombench/Makefile
+++ b/prombench/Makefile
@@ -1,9 +1,5 @@
 INFRA_CMD        ?= ../infra/infra
 
-ifeq ($(AUTH_FILE),)
-AUTH_FILE = /etc/serviceaccount/service-account.json
-endif
-
 .PHONY: deploy clean
 deploy: nodepool_create resource_apply
 # GCP sometimes takes longer than 30 tries when trying to delete nodepools

--- a/prombench/README.md
+++ b/prombench/README.md
@@ -67,7 +67,6 @@ export GITHUB_REPO=prometheus
     -v GCLOUD_SERVICEACCOUNT_CLIENT_EMAIL:$GCLOUD_SERVICEACCOUNT_CLIENT_EMAIL \
     -v OAUTH_TOKEN="$(printf $OAUTH_TOKEN | base64 -w 0)" \
     -v WH_SECRET="$(printf $WH_SECRET | base64 -w 0)" \
-    -v GKE_AUTH="$(cat $AUTH_FILE | base64 -w 0)" \
     -v GITHUB_ORG:$GITHUB_ORG -v GITHUB_REPO:$GITHUB_REPO \
     -f manifests/cluster-infra
 ```

--- a/prombench/manifests/cluster-infra/1b_secrets.yaml
+++ b/prombench/manifests/cluster-infra/1b_secrets.yaml
@@ -9,14 +9,6 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: service-account
-type: Opaque
-data:
-  service-account.json: "{{ .GKE_AUTH }}"
----
-apiVersion: v1
-kind: Secret
-metadata:
   name: whsecret
 type: Opaque
 data:


### PR DESCRIPTION
Signed-off-by: Raj Babu Das <mail.rajdas@gmail.com>
- To support the PR https://github.com/prometheus/test-infra/pull/390, we need to remove this unused service-account secret from 1b_secret

- [x] Tested in GKE https://gist.github.com/rajdas98/c811dd665398bbf7ca00dabfd19267e8
