### PR TITLE
Remove verifyUserDisabled and add verify_user to commentMonitor config

### DIFF
--- a/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
+++ b/prombench/manifests/cluster-infra/7a_commentmonitor_configmap_noparse.yaml
@@ -8,9 +8,11 @@ data:
       - prefix: /prombench
         help_template: |
           Incorrect prombench syntax, please find [correct syntax here](https://github.com/prometheus/test-infra/tree/master/prombench#trigger-tests-via-a-github-comment).
+        verify_user: true
       - prefix: /funcbench
         help_template: |
           Incorrect funcbench syntax, please find [correct syntax here](https://github.com/prometheus/test-infra/tree/master/funcbench#triggering-with-github-comments).
+        verify_user: false
     events:
       - event_type: prombench_start
         regex_string: (?mi)^/prombench\s*(?P<RELEASE>master|v[0-9]+\.[0-9]+\.[0-9]+\S*)\s*$

--- a/tools/commentMonitor/README.md
+++ b/tools/commentMonitor/README.md
@@ -57,7 +57,6 @@ Flags:
                                and --help-man).
       --webhooksecretfile="./whsecret"
                                path to webhook secret file
-      --no-verify-user         disable verifying user
       --config="./config.yml"  Filepath to config file.
       --port="8080"            port number to run webhook in.
 

--- a/tools/commentMonitor/client.go
+++ b/tools/commentMonitor/client.go
@@ -31,6 +31,7 @@ type commentMonitorClient struct {
 	events             []webhookEvent
 	prefixes           []commandPrefix
 	prefixHelpTemplate string
+	prefixVerifyUser   bool
 	eventType          string
 	commentTemplate    string
 	label              string
@@ -56,6 +57,7 @@ func (c *commentMonitorClient) checkCommandPrefix(command string) bool {
 	for _, p := range c.prefixes {
 		if strings.HasPrefix(command, p.Prefix) {
 			c.prefixHelpTemplate = p.HelpTemplate
+			c.prefixVerifyUser = p.VerifyUser
 			return true
 		}
 	}
@@ -63,8 +65,8 @@ func (c *commentMonitorClient) checkCommandPrefix(command string) bool {
 }
 
 // Verify if user is allowed to perform activity.
-func (c commentMonitorClient) verifyUser(verifyUserDisabled bool) error {
-	if !verifyUserDisabled {
+func (c commentMonitorClient) verifyUser() error {
+	if c.prefixVerifyUser {
 		var allowed bool
 		allowedAssociations := []string{"COLLABORATOR", "MEMBER", "OWNER"}
 		for _, a := range allowedAssociations {

--- a/tools/commentMonitor/client.go
+++ b/tools/commentMonitor/client.go
@@ -25,16 +25,16 @@ import (
 )
 
 type commentMonitorClient struct {
-	ghClient           *githubClient
-	allArgs            map[string]string
-	regex              *regexp.Regexp
-	events             []webhookEvent
-	prefixes           []commandPrefix
-	prefixHelpTemplate string
-	prefixVerifyUser   bool
-	eventType          string
-	commentTemplate    string
-	label              string
+	ghClient         *githubClient
+	allArgs          map[string]string
+	regex            *regexp.Regexp
+	events           []webhookEvent
+	prefixes         []commandPrefix
+	helpTemplate     string
+	shouldVerifyUser bool
+	eventType        string
+	commentTemplate  string
+	label            string
 }
 
 // Set eventType and commentTemplate if
@@ -56,8 +56,8 @@ func (c *commentMonitorClient) validateRegex(command string) bool {
 func (c *commentMonitorClient) checkCommandPrefix(command string) bool {
 	for _, p := range c.prefixes {
 		if strings.HasPrefix(command, p.Prefix) {
-			c.prefixHelpTemplate = p.HelpTemplate
-			c.prefixVerifyUser = p.VerifyUser
+			c.helpTemplate = p.HelpTemplate
+			c.shouldVerifyUser = p.VerifyUser
 			return true
 		}
 	}
@@ -66,7 +66,7 @@ func (c *commentMonitorClient) checkCommandPrefix(command string) bool {
 
 // Verify if user is allowed to perform activity.
 func (c commentMonitorClient) verifyUser() error {
-	if c.prefixVerifyUser {
+	if c.shouldVerifyUser {
 		var allowed bool
 		allowedAssociations := []string{"COLLABORATOR", "MEMBER", "OWNER"}
 		for _, a := range allowedAssociations {
@@ -130,7 +130,7 @@ func (c commentMonitorClient) generateAndPostSuccessComment() error {
 	return c.generateAndPostComment(c.commentTemplate)
 }
 func (c commentMonitorClient) generateAndPostErrorComment() error {
-	return c.generateAndPostComment(c.prefixHelpTemplate)
+	return c.generateAndPostComment(c.helpTemplate)
 }
 
 func (c commentMonitorClient) generateAndPostComment(commentTemplate string) error {

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -29,17 +29,17 @@ import (
 )
 
 type commentMonitorConfig struct {
-	verifyUserDisabled bool
-	configFilePath     string
-	whSecretFilePath   string
-	whSecret           []byte
-	configFile         configFile
-	port               string
+	configFilePath   string
+	whSecretFilePath string
+	whSecret         []byte
+	configFile       configFile
+	port             string
 }
 
 type commandPrefix struct {
 	Prefix       string `yaml:"prefix"`
 	HelpTemplate string `yaml:"help_template"`
+	VerifyUser   bool   `yaml:"verify_user"`
 }
 
 type webhookEvent struct {
@@ -63,8 +63,6 @@ func main() {
 	app.Flag("webhooksecretfile", "path to webhook secret file").
 		Default("./whsecret").
 		StringVar(&cmConfig.whSecretFilePath)
-	app.Flag("no-verify-user", "disable verifying user").
-		BoolVar(&cmConfig.verifyUserDisabled)
 	app.Flag("config", "Filepath to config file.").
 		Default("./config.yml").
 		StringVar(&cmConfig.configFilePath)
@@ -183,7 +181,7 @@ func (c *commentMonitorConfig) webhookExtract(w http.ResponseWriter, r *http.Req
 		}
 
 		// Verify user.
-		err = cmClient.verifyUser(c.verifyUserDisabled)
+		err = cmClient.verifyUser()
 		if err != nil {
 			log.Println(err)
 			http.Error(w, "user not allowed to run command", http.StatusForbidden)

--- a/tools/commentMonitor/main_test.go
+++ b/tools/commentMonitor/main_test.go
@@ -37,9 +37,9 @@ func TestExtractCommand(t *testing.T) {
 func TestCheckCommandPrefix(t *testing.T) {
 	cmClient := commentMonitorClient{
 		prefixes: []commandPrefix{
-			{"/funcbench", "help"},
-			{"/prombench", "help"},
-			{"/somebench", "help"},
+			{"/funcbench", "help", false},
+			{"/prombench", "help", false},
+			{"/somebench", "help", false},
 		},
 	}
 	testCases := []struct {


### PR DESCRIPTION
Added to allow funcbench to be run by any GitHub user.

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>