### PR TITLE
Make -delta-test=none default for benchstat in funcbench

### DIFF
--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -114,7 +114,9 @@ func (b *Benchmarker) compareSubBenchmarks(string) ([]*benchstat.Table, error) {
 }
 
 func compareBenchmarks(files ...string) ([]*benchstat.Table, error) {
-	c := &benchstat.Collection{}
+	c := &benchstat.Collection{
+		DeltaTest: benchstat.NoDeltaTest,
+	}
 
 	for _, file := range files {
 		f, err := os.Open(file)


### PR DESCRIPTION
See: https://github.com/prometheus/prometheus/pull/7733#issuecomment-671843580

Example results:
```
...
Results:
Old: e91f7e1c0a96ccfbe78ca53a1957f78253955f76
New: bf9fdd1463f2d6527ba651dbadab8f96b2cb9ca0
name               old time/op    new time/op    delta
Isolation/10-8       2.03µs ± 0%    2.03µs ± 0%   -0.34%
Isolation/100-8      22.6µs ± 0%    22.1µs ± 0%   -2.19%
Isolation/1000-8      281µs ± 0%     275µs ± 0%   -2.11%
Isolation/10000-8    2.84ms ± 0%    3.08ms ± 0%   +8.65%

name               old alloc/op   new alloc/op   delta
Isolation/10-8        0.00B          0.00B         0.00%
Isolation/100-8       2.00B ± 0%     2.00B ± 0%    0.00%
Isolation/1000-8      74.0B ± 0%     45.0B ± 0%  -39.19%
Isolation/10000-8    2.60kB ± 0%    2.54kB ± 0%   -2.31%

name               old allocs/op  new allocs/op  delta
Isolation/10-8         0.00           0.00         0.00%
Isolation/100-8        0.00           0.00         0.00%
Isolation/1000-8       0.00           0.00         0.00%
Isolation/10000-8      20.0 ± 0%      20.0 ± 0%    0.00%
funcbech00:55:15 main.go:211: exiting
```

cc @krasi-georgiev @bwplotka @nevill 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>