### PR TITLE
Add enhancement flags to funcbench

### DIFF
--- a/funcbench/README.md
+++ b/funcbench/README.md
@@ -36,14 +36,19 @@ Flags:
                              benchmark results.
       --workspace="/tmp/funcbench"
                              Directory to clone GitHub PR.
-      --result-cache="_dev/funcbench"
+      --result-cache="funcbench-results"
                              Directory to store benchmark results.
+  -n, --user-test-name="default"
+                             Name of the test to keep track of multiple
+                             benchmarks
   -t, --bench-time=1s        Run enough iterations of each benchmark to take t,
                              specified as a time.Duration. The special syntax Nx
                              means to run the benchmark N times
   -d, --timeout=2h           Benchmark timeout specified in time.Duration
                              format, disabled if set to 0. If a test binary runs
                              longer than duration d, panic.
+  -l, --perflock             Enable perflock (you must have perflock installed
+                             to use this)
 
 Args:
   <target>              Can be one of '.', tag name, branch name or commit SHA

--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -32,15 +32,19 @@ import (
 type Benchmarker struct {
 	logger Logger
 
-	benchmarkArgs  []string
-	benchFunc      string
-	resultCacheDir string
+	benchmarkArgs       []string
+	benchFunc           string
+	resultCacheDir      string
+	scratchWorkspaceDir string
+	enablePerflock      bool
 
 	c    *commander
 	repo *git.Repository
 }
 
-func newBenchmarker(logger Logger, env Environment, c *commander, benchTime time.Duration, benchTimeout time.Duration, resultCacheDir, packagePath string) *Benchmarker {
+func newBenchmarker(logger Logger, env Environment, c *commander,
+	benchTime, benchTimeout time.Duration,
+	resultCacheDir, packagePath string, enablePerflock bool) *Benchmarker {
 	return &Benchmarker{
 		logger:    logger,
 		benchFunc: env.BenchFunc(),
@@ -56,9 +60,11 @@ func newBenchmarker(logger Logger, env Environment, c *commander, benchTime time
 			"-timeout", benchTimeout.String(),
 			packagePath,
 		},
-		c:              c,
-		repo:           env.Repo(),
-		resultCacheDir: resultCacheDir,
+		c:                   c,
+		repo:                env.Repo(),
+		resultCacheDir:      resultCacheDir,
+		scratchWorkspaceDir: "/tmp/funcbench-scratch",
+		enablePerflock:      enablePerflock,
 	}
 }
 
@@ -91,6 +97,9 @@ func (b *Benchmarker) exec(pkgRoot string, commit plumbing.Hash) (string, error)
 	benchCmd := []string{"sh", "-c", strings.Join(append([]string{"cd", pkgRoot, "&&"}, b.benchmarkArgs...), " ")}
 
 	b.logger.Println("Executing benchmark command for", commit.String(), "\n", benchCmd)
+	if b.enablePerflock {
+		benchCmd = append([]string{"perflock"}, benchCmd...)
+	}
 	out, err := b.c.exec(benchCmd...)
 	if err != nil {
 		return "", errors.Wrap(err, "benchmark ended with an error.")


### PR DESCRIPTION
for #431 

## Behavior:
```shell
$ git checkout master
# both master and e208afcc957f056728b4e44af9103aedfc15a76f are evaluated
$ ./funcbench -n "lazydaytest" e208afcc957f056728b4e44af9103aedfc15a76f "BenchmarkIsolation*" ./tsdb

# cached data is fetched for both
$ ./funcbench -n "lazydaytest" e208afcc957f056728b4e44af9103aedfc15a76f "BenchmarkIsolation*" ./tsdb

# cached data is fetched only for master
$ ./funcbench -n "lazydaytest" 6f28c46f4c8812b124ce9bc5ebfd803974f7ec2d "BenchmarkIsolation*" ./tsdb

$ git checkout e208afcc957f056728b4e44af9103aedfc15a76f
# cached data is fetched for both
$ ./funcbench -n "lazydaytest" 6f28c46f4c8812b124ce9bc5ebfd803974f7ec2d "BenchmarkIsolation*" ./tsdb

$ pwd
/home/geekodour/OpenSource/prometheus/funcbench-results
$ tree
.
└── lazydaytest
    ├── QmVuY2htYXJrSXNvbGF0aW9uKg==-6f28c46f4c8812b124ce9bc5ebfd803974f7ec2d.out
    ├── QmVuY2htYXJrSXNvbGF0aW9uKg==-db13003721bf185f695ed63d6cff5c156042a4f3.out
    └── QmVuY2htYXJrSXNvbGF0aW9uKg==-e208afcc957f056728b4e44af9103aedfc15a76f.out

```

## Changes:

* Update default value of result cache
* Add `--user-test-name` flag to help identify tests
* Add `--perflock` flag for perflock support
* Checkout git worktree of target in a temporary directory

## Questions: 
> Then we do C, D, E and we usually compare with A and don't want to redo A all the time. Funbench however by design always do A and Target commit.

funcbench currently does not **always** do A and target commit, if they are cached, the cached versions will be used. (It does not however store the output of the comparison though). Did you mean something else, or I might be misunderstanding here?

To work on the workflow you mentioned, I can simply have the commits A,B,C,D,E and then be on one of branch (in our case `A` and just call funcbench for the other commits. won't this suffice?
```bash
git checkout A
for commit in B C D E
do
  ./funcbench -n "lazydaytest" $commit "BenchmarkIsolation*" ./tsdb
done

```

## Notes
- It'd be nice to make funcbench go gettable, but it would need funcbench to have its own go.mod file no? (I am unfamilar with publishing go packages) :( 
- `funcbench-results` should be gitignored.

cc: @bwplotka @krasi-georgiev 

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>