### PR TITLE
Update path to executable in $PATH for infra in GH Grafana workflow

### DIFF
--- a/.github/workflows/grafana_dashboard.yaml
+++ b/.github/workflows/grafana_dashboard.yaml
@@ -21,7 +21,7 @@ jobs:
         TEST_INFRA_REPO: https://github.com/prometheus/test-infra.git
       with:
         args: >-
-          ../infra/infra gke resource apply -a $AUTH_FILE
+          infra gke resource apply -a $AUTH_FILE
           -v GKE_PROJECT_ID:$GKE_PROJECT_ID -v ZONE:$ZONE
           -v CLUSTER_NAME:$CLUSTER_NAME
           -f manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml


### PR DESCRIPTION
Fix added in #440 was incorrect (used local path instead of path to executable in dockeimage)

Signed-off-by: Hrishikesh Barman <hrishikeshbman@gmail.com>