### PR TITLE
Update Prometheus Meta to the last version (2.35)

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -201,7 +201,7 @@ spec:
       securityContext:
         runAsUser: 0
       containers:
-      - image: quay.io/prometheus/prometheus:v2.20.0
+      - image: quay.io/prometheus/prometheus:v2.35.0
         args:
         - "--config.file=/etc/prometheus/config/prometheus.yaml"
         - "--storage.tsdb.path=/data"


### PR DESCRIPTION
Update Prometheus Meta version as specified in #455. 
@geekodour 