### PR TITLE
Remove ioutil

### DIFF
--- a/funcbench/bench.go
+++ b/funcbench/bench.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -82,7 +81,7 @@ func (b *Benchmarker) exec(pkgRoot string, commit plumbing.Hash) (string, error)
 		return "", err
 	}
 
-	if _, err := ioutil.ReadFile(filepath.Join(b.resultCacheDir, fileName)); err == nil {
+	if _, err := os.ReadFile(filepath.Join(b.resultCacheDir, fileName)); err == nil {
 		fmt.Println("Found previous results for ", fileName, b.benchFunc, "Reusing.")
 		return filepath.Join(b.resultCacheDir, fileName), nil
 	}
@@ -102,7 +101,7 @@ func (b *Benchmarker) exec(pkgRoot string, commit plumbing.Hash) (string, error)
 			return "", err
 		}
 	}
-	if err := ioutil.WriteFile(fn, []byte(out), os.ModePerm); err != nil {
+	if err := os.WriteFile(fn, []byte(out), os.ModePerm); err != nil {
 		return "", err
 	}
 	return fn, nil

--- a/funcbench/benchstat_test.go
+++ b/funcbench/benchstat_test.go
@@ -14,7 +14,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -73,7 +73,7 @@ BenchmarkIsolation/10-8	445276	2478 ns/op	0 B/op	0 allocs/op
 	file2 := `
 BenchmarkIsolation/100-8	39044	28747 ns/op	6 B/op	0 allocs/op
 `
-	dir, err := ioutil.TempDir("", "test_empty_result")
+	dir, err := os.MkdirTemp("", "test_empty_result")
 	if err != nil {
 		t.Error(err)
 	}
@@ -86,7 +86,7 @@ BenchmarkIsolation/100-8	39044	28747 ns/op	6 B/op	0 allocs/op
 	names := make([]string, 0)
 	for name, content := range files {
 		f := filepath.Join(dir, name)
-		if err := ioutil.WriteFile(f, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(f, []byte(content), 0644); err != nil {
 			t.Error(err)
 			return
 		}

--- a/pkg/provider/eks/eks.go
+++ b/pkg/provider/eks/eks.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -90,7 +89,7 @@ func (c *EKS) NewEKSClient(*kingpin.ParseContext) error {
 
 	// When the auth variable points to a file
 	// put the file content in the variable.
-	if content, err := ioutil.ReadFile(c.Auth); err == nil {
+	if content, err := os.ReadFile(c.Auth); err == nil {
 		c.Auth = string(content)
 	}
 

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"regexp"
@@ -85,7 +84,7 @@ func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 
 	// When the auth variable points to a file
 	// put the file content in the variable.
-	if content, err := ioutil.ReadFile(c.Auth); err == nil {
+	if content, err := os.ReadFile(c.Auth); err == nil {
 		c.Auth = string(content)
 	}
 
@@ -103,7 +102,7 @@ func (c *GKE) NewGKEClient(*kingpin.ParseContext) error {
 	}
 
 	// Create temporary file to store the credentials.
-	saFile, err := ioutil.TempFile("", "service-account")
+	saFile, err := os.CreateTemp("", "service-account")
 	if err != nil {
 		return errors.Wrap(err, "could not create temp file")
 	}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -16,7 +16,6 @@ package provider
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -119,7 +118,7 @@ func DeploymentsParse(deploymentFiles []string, deploymentVars map[string]string
 	deploymentObjects := make([]Resource, 0)
 	for _, name := range fileList {
 		absFileName := strings.TrimSuffix(filepath.Base(name), filepath.Ext(name))
-		content, err := ioutil.ReadFile(name)
+		content, err := os.ReadFile(name)
 		if err != nil {
 			log.Fatalf("Error reading file %v:%v", name, err)
 		}

--- a/tools/amGithubNotifier/main.go
+++ b/tools/amGithubNotifier/main.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -137,7 +136,7 @@ func newGhWebhookReceiver(cfg ghWebhookReceiverConfig) (*ghWebhookReceiver, erro
 	}
 
 	// Add github token.
-	oauth2token, err := ioutil.ReadFile(cfg.authFile)
+	oauth2token, err := os.ReadFile(cfg.authFile)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/commentMonitor/main.go
+++ b/tools/commentMonitor/main.go
@@ -16,7 +16,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -79,7 +78,7 @@ func main() {
 
 func (c *commentMonitorConfig) loadConfig() error {
 	// Get config file.
-	data, err := ioutil.ReadFile(c.configFilePath)
+	data, err := os.ReadFile(c.configFilePath)
 	if err != nil {
 		return err
 	}
@@ -91,7 +90,7 @@ func (c *commentMonitorConfig) loadConfig() error {
 		return fmt.Errorf("empty eventmap or prefix list")
 	}
 	// Get webhook secret.
-	c.whSecret, err = ioutil.ReadFile(c.whSecretFilePath)
+	c.whSecret, err = os.ReadFile(c.whSecretFilePath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>