### PR TITLE
moved loader=yaml.FullLoader to correct place

### DIFF
--- a/tools/load-generator/main.py
+++ b/tools/load-generator/main.py
@@ -118,7 +118,7 @@ def main():
     namespace = sys.argv[1]
     pr_number = sys.argv[2]
 
-    config = yaml.load(open("/etc/loadgen/config.yaml", 'r', Loader=yaml.FullLoader).read())
+    config = yaml.load(open("/etc/loadgen/config.yaml", 'r').read(), Loader=yaml.FullLoader)
 
     print("loaded configuration")
 


### PR DESCRIPTION
Loader type is an argument for yaml.load function not the open function 