### PR TITLE
Update GKE Node pool base image

### DIFF
--- a/prombench/manifests/prombench/nodes_gke.yaml
+++ b/prombench/manifests/prombench/nodes_gke.yaml
@@ -8,7 +8,7 @@ cluster:
     initialnodecount: 2
     config:
       machinetype: n1-highmem-8
-      imagetype: COS
+      imagetype: COS_CONTAINERD
       disksizegb: 100
       localssdcount: 1  #SSD is used to give fast-lookup to Prometheus servers being benchmarked
       labels:
@@ -18,7 +18,7 @@ cluster:
     initialnodecount: 1
     config:
       machinetype: n1-highcpu-16
-      imagetype: COS
+      imagetype: COS_CONTAINERD
       disksizegb: 100
       localssdcount: 0  #use standard HDD. SSD not needed for fake-webservers.
       labels:


### PR DESCRIPTION
Google has deprectated the use of docker based images. Instead they want you to use containerd based images.

Here is the deprecation notice https://cloud.google.com/kubernetes-engine/docs/deprecations/docker-containerd

Prombench is failing to start due to this.