### PR TITLE
Upgrading the GKE Version from 1.14 to 1.25

### DIFF
--- a/prombench/manifests/cluster-infra/2_ingress-nginx-controller.yaml
+++ b/prombench/manifests/cluster-infra/2_ingress-nginx-controller.yaml
@@ -247,7 +247,7 @@ spec:
       serviceAccountName: nginx-ingress-serviceaccount
       containers:
         - name: nginx-ingress-controller
-          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0
+          image: k8s.gcr.io/ingress-nginx/controller:v1.1.1
           args:
             - /nginx-ingress-controller
             - --configmap=$(POD_NAMESPACE)/nginx-configuration

--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -252,7 +252,7 @@ spec:
     prometheus: meta
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-prometheus-meta
@@ -264,6 +264,9 @@ spec:
   - http:
       paths:
       - backend:
-          serviceName: prometheus-meta
-          servicePort: prom-web
+          service:
+            name: prometheus-meta
+            port:
+              name: prom-web
         path: /prometheus-meta
+        pathType: Prefix

--- a/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
+++ b/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
@@ -65,7 +65,7 @@ spec:
     app: comment-monitor
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-comment-monitor
@@ -77,6 +77,9 @@ spec:
   - http:
       paths:
       - backend:
-          serviceName: comment-monitor
-          servicePort: cm-port
+          service:
+            name: comment-monitor
+            port:
+              name: cm-port
         path: /hook
+        pathType: Prefix

--- a/prombench/manifests/cluster-infra/grafana_deployment.yaml
+++ b/prombench/manifests/cluster-infra/grafana_deployment.yaml
@@ -90,7 +90,7 @@ spec:
     component: core
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-grafana
@@ -102,6 +102,9 @@ spec:
   - http:
       paths:
       - backend:
-          serviceName: grafana
-          servicePort: grafana-web
+          service:
+            name: grafana
+            port:
+              name: grafana-web
         path: /grafana
+        pathType: Prefix

--- a/prombench/manifests/cluster_gke.yaml
+++ b/prombench/manifests/cluster_gke.yaml
@@ -2,7 +2,9 @@ projectid: {{ .GKE_PROJECT_ID }}
 zone: {{ .ZONE }}
 cluster:
   name: {{ .CLUSTER_NAME }}
-  initialclusterversion: 1.14
+  
+  initialclusterversion: 1.25
+  
   nodepools:
   # This node-pool will be used for running monitoring components
   - name: main-node


### PR DESCRIPTION
Prombench uses GKE version 1.14 (which is end of life and end of support - https://cloud.google.com/kubernetes-engine/docs/release-schedule).

This commit updates the GKE version to 1.25 (latest default as of 2023-06-20)..

---

This change has been tested and it seems to be working fine:
- GKE Cluster Version - ![image](https://github.com/prometheus/test-infra/assets/23132557/35a4bea9-68b8-4a01-aa2c-1eb4b70e365a)

- Grafana dashboard - ![image](https://github.com/prometheus/test-infra/assets/23132557/ec872686-f992-4e00-9568-7f9740982795)



