### PR TITLE
Update ingress-prometheus apiVersion

### DIFF
--- a/prombench/manifests/prombench/benchmark/5_nginx-ingress-routes.yaml
+++ b/prombench/manifests/prombench/benchmark/5_nginx-ingress-routes.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ingress-prometheus


### PR DESCRIPTION
Prombench is still not working perfectly. It fails on the 5th manifest https://github.com/prometheus/prometheus/actions/runs/5291254588/jobs/9576542806 reason being:

`15:06:14 gke.go:594: error while applying a resource err:error applying 'manifests/prombench/benchmark/5_nginx-ingress-routes.yaml' err:error listing resource : Ingress, name: ingress-prometheus: the server could not find the requested resource (get ingresses.extensions)`

After a quick lookup I noticed ingresses are no longer behind extensions but behind the networking api.

``` 
❯ kubectl api-resources | grep ingress
ingressclasses                                 networking.k8s.io/v1                   false        IngressClass
ingresses                         ing          networking.k8s.io/v1                   true         Ingress
```