### PR TITLE
Increase prometheus ingress timeouts

### DIFF
--- a/prombench/manifests/prombench/benchmark/5_nginx-ingress-routes.yaml
+++ b/prombench/manifests/prombench/benchmark/5_nginx-ingress-routes.yaml
@@ -6,6 +6,9 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/proxy-connect-timeout: '605'
+    nginx.ingress.kubernetes.io/proxy-send-timeout: '605'
+    nginx.ingress.kubernetes.io/proxy-read-timeout: '605'
 spec:
   rules:
   - http:


### PR DESCRIPTION
This PR is increasing the ingress timeouts. This is useful to get meaningful profiles from the running instances.