### PR TITLE
Changing loki's table manager retention period

### DIFF
--- a/prombench/manifests/cluster-infra/6b_loki_stateful_set.yaml
+++ b/prombench/manifests/cluster-infra/6b_loki_stateful_set.yaml
@@ -39,7 +39,7 @@ data:
       max_look_back_period: 0s
     table_manager:
       retention_deletes_enabled: true
-      retention_period: 2160h
+      retention_period: 2184h
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Loki's table manager component requires the retention period to be a multiple of the index period value. The initial retention period value was changed from 0 (which is also an acceptable value) to 2160h in this commit: https://github.com/prometheus/test-infra/commit/b3538956b850c4e2db3183f1bfcd1ab65d6e5e4a which throws an error while deploying loki.

Reference:
- https://github.com/grafana/loki/blob/main/docs/sources/storage/_index.md?plain=1#L122-L127
- https://github.com/grafana/loki/issues/2151#issuecomment-636850837