### PR TITLE
Parca: update to 0.20.0

### DIFF
--- a/prombench/manifests/cluster-infra/8b_parca.yaml
+++ b/prombench/manifests/cluster-infra/8b_parca.yaml
@@ -74,7 +74,7 @@ spec:
         fsGroup: 65534
         runAsUser: 65534
       containers:
-      - image: ghcr.io/parca-dev/parca:v0.18.0
+      - image: ghcr.io/parca-dev/parca:v0.20.0
         args:
           - /parca
           - "--http-address=:7070"


### PR DESCRIPTION
I saw some faults with the UI, and apparently it has been rewritten between 0.18 and 0.20.

Didn't see any breaking changes listed, but I have no idea whether it will work.
