### PR TITLE
Update prometheus builder to Go 1.21

### DIFF
--- a/tools/prometheus-builder/Dockerfile
+++ b/tools/prometheus-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/prometheus/golang-builder:1.20-main
+FROM quay.io/prometheus/golang-builder:1.21-main
 
 RUN mkdir -p /go/src/github.com
 COPY ./build.sh /go/src/github.com/build.sh


### PR DESCRIPTION
It's unfortunate this does not update at the same time as the Prometheus repo.
