### PR TITLE
Update prometheus builder to Go 1.22

### DIFF
--- a/tools/prometheus-builder/Dockerfile
+++ b/tools/prometheus-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/prometheus/golang-builder:1.21-main
+FROM quay.io/prometheus/golang-builder:1.22-main
 
 RUN mkdir -p /go/src/github.com
 COPY ./build.sh /go/src/github.com/build.sh


### PR DESCRIPTION
Since Prometheus main branch is now building with Go 1.22, prombench should do the same.
