### PR TITLE
Grafana: Fix `pr-number` variable

### DIFF
--- a/prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
+++ b/prombench/manifests/cluster-infra/grafana_dashboard_dashboards_noparse.yaml
@@ -1573,7 +1573,7 @@ data:
               "steppedLine": false,
               "targets": [
               {
-                  "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}",
+                  "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
                   "format": "time_series",
                   "hide": false,
                   "intervalFactor": 1,
@@ -1581,28 +1581,28 @@ data:
                   "refId": "E"
               },
               {
-                  "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"} - node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"} - node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"} - node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}",
+                  "expr": "node_memory_MemTotal_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"} - node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - Used",
                   "refId": "A"
               },
               {
-                  "expr": "node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}",
+                  "expr": "node_memory_Buffers_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - Buffers",
                   "refId": "B"
               },
               {
-                  "expr": "node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}",
+                  "expr": "node_memory_Cached_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - Cached",
                   "refId": "C"
               },
               {
-                  "expr": "node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}",
+                  "expr": "node_memory_MemFree_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - Free",
@@ -1682,7 +1682,7 @@ data:
               "steppedLine": false,
               "targets": [
               {
-                  "expr": "irate(node_disk_io_time_seconds_total{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\",device!~'^(md\\\\\\\\d+$|dm-)'}[5m])",
+                  "expr": "irate(node_disk_io_time_seconds_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'^(md\\\\\\\\d+$|dm-)'}[5m])",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - {{device}}",
@@ -1762,14 +1762,14 @@ data:
               "steppedLine": false,
               "targets": [
               {
-                  "expr": "irate(node_context_switches_total{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}[5m])",
+                  "expr": "irate(node_context_switches_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - Context Switches",
                   "refId": "A"
               },
               {
-                  "expr": "irate(node_intr_total{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}[5m])",
+                  "expr": "irate(node_intr_total{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}[5m])",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - Interrupts",
@@ -1851,7 +1851,7 @@ data:
               "steppedLine": false,
               "targets": [
               {
-                  "expr": "100 - ((node_filesystem_avail_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{node=~'(test+).*',device!~'rootfs'})",
+                  "expr": "100 - ((node_filesystem_avail_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",device!~'rootfs'} * 100) / node_filesystem_size_bytes{node=~'(test+).*',device!~'rootfs'})",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - {{mountpoint}}",
@@ -1933,21 +1933,21 @@ data:
               "steppedLine": false,
               "targets": [
               {
-                  "expr": "node_load1{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}",
+                  "expr": "node_load1{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - Load 1m",
                   "refId": "A"
               },
               {
-                  "expr": "node_load5{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}",
+                  "expr": "node_load5{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - Load 5m",
                   "refId": "B"
               },
               {
-                  "expr": "node_load15{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}",
+                  "expr": "node_load15{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - Load 15m",
@@ -2027,7 +2027,7 @@ data:
               "steppedLine": false,
               "targets": [
               {
-                  "expr": "1 - node_filesystem_free_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\",fstype!='rootfs',mountpoint!~'/(run|var).*',mountpoint!=''} / node_filesystem_size_bytes{job=\"node-exporter\",namespace=\"prombench-[[pr-number]]\",node=~\"(test+).*\"}",
+                  "expr": "1 - node_filesystem_free_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\",fstype!='rootfs',mountpoint!~'/(run|var).*',mountpoint!=''} / node_filesystem_size_bytes{job=\"node-exporter\",namespace=\"prombench-${prNumber}\",node=~\"(test+).*\"}",
                   "format": "time_series",
                   "intervalFactor": 1,
                   "legendFormat": "{{node}} - {{mountpoint}}",
@@ -2124,7 +2124,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "prometheus_build_info{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "prometheus_build_info{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{prometheus}} - {{version}} - {{revision}}",
@@ -2204,7 +2204,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "time() - process_start_time_seconds{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "time() - process_start_time_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{prometheus}} - Uptime",
@@ -2287,14 +2287,14 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "process_max_fds{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "process_max_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{prometheus}} - Max",
               "refId": "A"
           },
           {
-              "expr": "process_open_fds{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "process_open_fds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{prometheus}} - Open",
@@ -2382,7 +2382,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "prometheus_tsdb_head_series{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "prometheus_tsdb_head_series{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Time series",
@@ -2472,7 +2472,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "prometheus_tsdb_head_active_appenders{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "prometheus_tsdb_head_active_appenders{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Head Appenders",
@@ -2559,7 +2559,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_tsdb_head_samples_appended_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - samples/s",
@@ -2655,7 +2655,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "prometheus_tsdb_head_chunks{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Chunks",
@@ -2745,7 +2745,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_head_chunks_created_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_tsdb_head_chunks_created_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Created",
@@ -2836,7 +2836,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_head_chunks_removed_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_tsdb_head_chunks_removed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Removed",
@@ -2935,7 +2935,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "prometheus_tsdb_head_min_time{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "prometheus_tsdb_head_min_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Min",
@@ -2952,7 +2952,7 @@ data:
               "refId": "C"
           },
           {
-              "expr": "prometheus_tsdb_head_max_time{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "prometheus_tsdb_head_max_time{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Max",
@@ -3043,7 +3043,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_head_gc_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_tsdb_head_gc_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_head_gc_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - GC Time/s",
@@ -3138,7 +3138,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "prometheus_tsdb_blocks_loaded{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Blocks Loaded",
@@ -3230,7 +3230,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(go_memstats_alloc_bytes_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Allocated Bytes/s",
               "metric": "go_memstats_alloc_bytes",
@@ -3321,7 +3321,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_reloads_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3414,7 +3414,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_wal_corruptions_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_wal_corruptions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3424,7 +3424,7 @@ data:
               "step": 10
           },
           {
-              "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_reloads_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3434,7 +3434,7 @@ data:
               "step": 10
           },
           {
-              "expr": "rate(prometheus_tsdb_head_series_not_found{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_head_series_not_found{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3444,7 +3444,7 @@ data:
               "step": 10
           },
           {
-              "expr": "rate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_compactions_failed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3454,7 +3454,7 @@ data:
               "step": 10
           },
           {
-              "expr": "rate(prometheus_tsdb_retention_cutoffs_failures_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_retention_cutoffs_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3547,7 +3547,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_retention_cutoffs_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_retention_cutoffs_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Retention Cutoffs",
@@ -3638,7 +3638,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_wal_fsync_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_fsync_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_tsdb_wal_fsync_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_fsync_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3730,7 +3730,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_wal_truncate_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_truncate_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_tsdb_wal_truncate_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_tsdb_wal_truncate_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -3821,7 +3821,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_compaction_chunk_size_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_compaction_chunk_size_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_size_bytes_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Bytes/Sample",
@@ -3912,7 +3912,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_compaction_chunk_range_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_count{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_compaction_chunk_range_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) or rate(prometheus_tsdb_compaction_chunk_range_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_range_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Chunk Time Range",
@@ -4003,7 +4003,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_count{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_compaction_chunk_samples_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_chunk_samples_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Chunk Samples",
@@ -4094,7 +4094,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_compactions_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_compactions_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "interval": "",
               "intervalFactor": 2,
@@ -4185,7 +4185,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_tsdb_compaction_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[10m])",
+              "expr": "rate(prometheus_tsdb_compaction_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m]) / rate(prometheus_tsdb_compaction_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[10m])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -4275,7 +4275,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "irate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "irate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Irate",
               "metric": "prometheus_local_storage_ingested_samples_total",
@@ -4283,7 +4283,7 @@ data:
               "step": 10
           },
           {
-              "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[5m])",
+              "expr": "rate(process_cpu_seconds_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[5m])",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - 5m rate",
               "metric": "prometheus_local_storage_ingested_samples_total",
@@ -4386,7 +4386,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "process_resident_memory_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - RSS",
               "metric": "process_resident_memory_bytes",
@@ -4394,7 +4394,7 @@ data:
               "step": 10
           },
           {
-              "expr": "prometheus_local_storage_target_heap_size_bytes{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "prometheus_local_storage_target_heap_size_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Target heap size",
               "metric": "go_memstats_alloc_bytes",
@@ -4402,7 +4402,7 @@ data:
               "step": 10
           },
           {
-              "expr": "go_memstats_next_gc_bytes{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "go_memstats_next_gc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Next GC",
               "metric": "go_memstats_next_gc_bytes",
@@ -4410,7 +4410,7 @@ data:
               "step": 10
           },
           {
-              "expr": "go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+              "expr": "go_memstats_alloc_bytes{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Allocated",
               "metric": "go_memstats_alloc_bytes",
@@ -4500,7 +4500,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - {{handler}}",
@@ -4591,7 +4591,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_http_request_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_http_request_duration_seconds_count{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - {{handler}}",
@@ -4682,7 +4682,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"prepare_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -4774,7 +4774,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"inner_eval\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -4866,7 +4866,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"queue_time\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -4958,7 +4958,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_engine_query_duration_seconds_sum{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m]) / rate(prometheus_engine_query_duration_seconds_count{job=\"prometheus\",slice=\"result_sort\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 2,
@@ -5049,7 +5049,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])  ",
+              "expr": "rate(prometheus_rule_group_iterations_missed_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])  ",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Rule group missed",
@@ -5058,7 +5058,7 @@ data:
               "step": 10
           },
           {
-              "expr": "rate(prometheus_rule_evaluation_failures_total{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_rule_evaluation_failures_total{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Rule evals failed",
@@ -5148,7 +5148,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "rate(prometheus_rule_group_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}[1m])",
+              "expr": "rate(prometheus_rule_group_duration_seconds_sum{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}[1m])",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Rule evaluation duration",
@@ -5242,7 +5242,7 @@ data:
           "steppedLine": false,
           "targets": [
           {
-              "expr": "prometheus_rule_group_interval_seconds{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
+              "expr": "prometheus_rule_group_interval_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Interval",
@@ -5251,7 +5251,7 @@ data:
               "step": 10
           },
           {
-              "expr": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
+              "expr": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\",rule_group=~\"$RuleGroup\"}\n",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{prometheus}} - Last Duration",
@@ -5336,12 +5336,12 @@ data:
       "steppedLine": false,
       "targets": [
         {
-          "expr": "prometheus_tsdb_isolation_low_watermark{namespace='prombench-[[pr-number]]'}",
+          "expr": "prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
           "legendFormat": "{{prometheus}} - low watermark",
           "refId": "A"
         },
         {
-          "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-[[pr-number]]'}",
+          "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'}",
           "interval": "",
           "legendFormat": "{{prometheus}} - high watermark",
           "refId": "B"
@@ -5427,7 +5427,7 @@ data:
         "steppedLine": false,
         "targets": [
           {
-            "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-[[pr-number]]'} - prometheus_tsdb_isolation_low_watermark{namespace='prombench-[[pr-number]]'}",
+            "expr": "prometheus_tsdb_isolation_high_watermark{namespace='prombench-${prNumber}'} - prometheus_tsdb_isolation_low_watermark{namespace='prombench-${prNumber}'}",
             "legendFormat": "{{prometheus}}",
             "refId": "A"
           }
@@ -5489,7 +5489,7 @@ data:
             "multi": false,
             "name": "RuleGroup",
             "options": [],
-            "query": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-[[pr-number]]\",prometheus=~\"(test+).*\"}",
+            "query": "prometheus_rule_group_last_duration_seconds{job=\"prometheus\",namespace=\"prombench-${prNumber}\",prometheus=~\"(test+).*\"}",
             "refresh": 2,
             "regex": ".*rule_group=\"(.*?)\".*",
             "sort": 1,
@@ -5503,21 +5503,22 @@ data:
             "allValue": null,
             "current": {},
             "datasource": "prometheus-meta",
+            "definition": "label_values(namespace)",
+            "description": "PR number",
             "hide": 0,
             "includeAll": false,
-            "label": null,
             "multi": false,
-            "name": "pr-number",
+            "name": "prNumber",
             "options": [],
-            "query": "label_values(namespace)",
-            "refresh": 2,
+            "query": {
+              "query": "label_values(namespace)",
+              "refId": "StandardVariableQuery"
+            },
+            "refresh": 1,
             "regex": "prombench-(\\d+)",
+            "skipUrlSync": false,
             "sort": 0,
-            "tagValuesQuery": null,
-            "tags": [],
-            "tagsQuery": null,
-            "type": "query",
-            "useTags": false
+            "type": "query"
           }
         ]
       },


### PR DESCRIPTION
Rename `pr-number` Grafana dashboard variable to `prNumber`, since dashes are not allowed in Grafana variable names. As a result, the variable wasn't working. Also, switch to newer variable expansion syntax (`${prNumber}` instead of `[[prNumber]]`, as the latter is [deprecated](https://grafana.com/docs/grafana/latest/dashboards/variables/variable-syntax/#variable-syntax)).

The variable's JSON changed a bit apart from the name, since I regenerated it within Grafana.

NB: I've tested locally, not in GitHub Actions. Not sure why I only discovered this problem locally. When deploying prombench locally, the Grafana version is 9.4.3.