### PR TITLE
Support ingressClass K8s resource in K8s package

### DIFF
--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -144,7 +144,6 @@ func (c *K8s) DeploymentsParse(*kingpin.ParseContext) error {
 // ResourceApply applies k8s objects.
 // The input is a slice of structs containing the filename and the slice of k8s objects present in the file.
 func (c *K8s) ResourceApply(deployments []Resource) error {
-
 	var err error
 	for _, deployment := range deployments {
 		for _, resource := range deployment.Objects {
@@ -181,6 +180,8 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 				err = c.statefulSetApply(resource)
 			case "job":
 				err = c.jobApply(resource)
+			case "ingressclass":
+				err = c.ingressClassApply(resource)
 			default:
 				err = fmt.Errorf("creating request for unimplimented resource type:%v", kind)
 			}
@@ -195,7 +196,6 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 // ResourceDelete deletes k8s objects.
 // The input is a slice of structs containing the filename and the slice of k8s objects present in the file.
 func (c *K8s) ResourceDelete(deployments []Resource) error {
-
 	var err error
 	for _, deployment := range deployments {
 		for _, resource := range deployment.Objects {
@@ -232,6 +232,8 @@ func (c *K8s) ResourceDelete(deployments []Resource) error {
 				err = c.statefulSetDelete(resource)
 			case "job":
 				err = c.jobDelete(resource)
+			case "ingressclass":
+				err = c.ingressClassDelete(resource)
 			default:
 				err = fmt.Errorf("deleting request for unimplimented resource type:%v", kind)
 			}
@@ -629,6 +631,44 @@ func (c *K8s) ingressApply(resource runtime.Object) error {
 	return nil
 }
 
+func (c *K8s) ingressClassApply(resource runtime.Object) error {
+	req, ok := resource.(*apiNetworkingV1.IngressClass)
+	if !ok {
+		return fmt.Errorf("expected IngressClass, but got %T", resource)
+	}
+	kind := resource.GetObjectKind().GroupVersionKind().Kind
+
+	if resource.GetObjectKind().GroupVersionKind().Version != "v1" {
+		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'",
+			resource.GetObjectKind().GroupVersionKind().Version, kind, req.Name)
+	}
+
+	client := c.clt.NetworkingV1().IngressClasses()
+	list, err := client.List(c.ctx, apiMetaV1.ListOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "error listing resource: %v, name: %v", kind, req.Name)
+	}
+
+	for _, l := range list.Items {
+		if l.Name == req.Name {
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, err := client.Update(c.ctx, req, apiMetaV1.UpdateOptions{})
+				return err
+			}); err != nil {
+				return errors.Wrapf(err, "resource update failed - kind: %v, name: %v", kind, req.Name)
+			}
+			log.Printf("resource updated - kind: %v, name: %v", kind, req.Name)
+			return nil
+		}
+	}
+
+	if _, err := client.Create(c.ctx, req, apiMetaV1.CreateOptions{}); err != nil {
+		return errors.Wrapf(err, "resource creation failed - kind: %v, name: %v", kind, req.Name)
+	}
+	log.Printf("resource created - kind: %v, name: %v", kind, req.Name)
+	return nil
+}
+
 func (c *K8s) nameSpaceApply(resource runtime.Object) error {
 	req := resource.(*apiCoreV1.Namespace)
 	kind := resource.GetObjectKind().GroupVersionKind().Kind
@@ -967,6 +1007,7 @@ func (c *K8s) clusterRoleBindingDelete(resource runtime.Object) error {
 	}
 	return nil
 }
+
 func (c *K8s) configMapDelete(resource runtime.Object) error {
 	req := resource.(*apiCoreV1.ConfigMap)
 	kind := resource.GetObjectKind().GroupVersionKind().Kind
@@ -1112,6 +1153,28 @@ func (c *K8s) ingressDelete(resource runtime.Object) error {
 	default:
 		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
 	}
+	return nil
+}
+
+func (c *K8s) ingressClassDelete(resource runtime.Object) error {
+	req, ok := resource.(*apiNetworkingV1.IngressClass)
+	if !ok {
+		return fmt.Errorf("expected IngressClass, but got %T", resource)
+	}
+	kind := resource.GetObjectKind().GroupVersionKind().Kind
+
+	if resource.GetObjectKind().GroupVersionKind().Version != "v1" {
+		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'",
+			resource.GetObjectKind().GroupVersionKind().Version, kind, req.Name)
+	}
+
+	client := c.clt.NetworkingV1().IngressClasses()
+	err := client.Delete(c.ctx, req.Name, apiMetaV1.DeleteOptions{})
+	if err != nil {
+		return errors.Wrapf(err, "resource deletion failed - kind: %v, name: %v", kind, req.Name)
+	}
+
+	log.Printf("resource deleted - kind: %v, name: %v", kind, req.Name)
 	return nil
 }
 


### PR DESCRIPTION
We don't support `ingressClass` Kubernetes resource, creating the cluster fails when we apply the [cluster-infra manifest](https://github.com/prometheus/test-infra/tree/master/prombench/manifests/cluster-infra) files.

We have ingressClass resource defined in our manifest files.

https://github.com/prometheus/test-infra/blob/master/prombench/manifests/cluster-infra/2_ingress-nginx-controller.yaml#L622-L633

fixes #717 
