### PR TITLE
Support Validating Webhook Configuration resource in K8s package

### DIFF
--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -562,6 +562,10 @@ func (c *K8s) validatingWebhookConfigurationApply(resource runtime.Object) error
 		}
 		var exists bool
 		for _, l := range list.Items {
+			if req.ResourceVersion == "" {
+				req.ResourceVersion = l.ResourceVersion
+			}
+
 			if l.Name == req.Name {
 				exists = true
 				break

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pkg/errors"
 	"gopkg.in/alecthomas/kingpin.v2"
+	admissionregistration "k8s.io/api/admissionregistration/v1"
 	appsV1 "k8s.io/api/apps/v1"
 	batchV1 "k8s.io/api/batch/v1"
 	apiCoreV1 "k8s.io/api/core/v1"
@@ -144,7 +145,6 @@ func (c *K8s) DeploymentsParse(*kingpin.ParseContext) error {
 // ResourceApply applies k8s objects.
 // The input is a slice of structs containing the filename and the slice of k8s objects present in the file.
 func (c *K8s) ResourceApply(deployments []Resource) error {
-
 	var err error
 	for _, deployment := range deployments {
 		for _, resource := range deployment.Objects {
@@ -181,6 +181,8 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 				err = c.statefulSetApply(resource)
 			case "job":
 				err = c.jobApply(resource)
+			case "validatingwebhookconfiguration":
+				err = c.validatingWebhookConfigurationApply(resource)
 			default:
 				err = fmt.Errorf("creating request for unimplimented resource type:%v", kind)
 			}
@@ -195,7 +197,6 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 // ResourceDelete deletes k8s objects.
 // The input is a slice of structs containing the filename and the slice of k8s objects present in the file.
 func (c *K8s) ResourceDelete(deployments []Resource) error {
-
 	var err error
 	for _, deployment := range deployments {
 		for _, resource := range deployment.Objects {
@@ -232,6 +233,8 @@ func (c *K8s) ResourceDelete(deployments []Resource) error {
 				err = c.statefulSetDelete(resource)
 			case "job":
 				err = c.jobDelete(resource)
+			case "validatingwebhookconfiguration":
+				err = c.validatingWebhookConfigurationDelete(resource)
 			default:
 				err = fmt.Errorf("deleting request for unimplimented resource type:%v", kind)
 			}
@@ -544,6 +547,44 @@ func (c *K8s) jobApply(resource runtime.Object) error {
 		fmt.Sprintf("running job:%v", req.Name),
 		Infinite,
 		func() (bool, error) { return c.jobReady(resource) })
+}
+
+func (c *K8s) validatingWebhookConfigurationApply(resource runtime.Object) error {
+	req := resource.(*admissionregistration.ValidatingWebhookConfiguration)
+	kind := resource.GetObjectKind().GroupVersionKind().Kind
+
+	switch v := resource.GetObjectKind().GroupVersionKind().Version; v {
+	case "v1":
+		client := c.clt.AdmissionregistrationV1().ValidatingWebhookConfigurations()
+		list, err := client.List(c.ctx, apiMetaV1.ListOptions{})
+		if err != nil {
+			return errors.Wrapf(err, "error listing resource : %v, name: %v", kind, req.Name)
+		}
+		var exists bool
+		for _, l := range list.Items {
+			if l.Name == req.Name {
+				exists = true
+				break
+			}
+		}
+
+		if exists {
+			if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+				_, err := client.Update(c.ctx, req, apiMetaV1.UpdateOptions{})
+				return err
+			}); err != nil {
+				return errors.Wrapf(err, "resource update failed - kind: %v, name: %v", kind, req.Name)
+			}
+			log.Printf("resource updated - kind: %v, name: %v", kind, req.Name)
+			return nil
+		} else if _, err := client.Create(c.ctx, req, apiMetaV1.CreateOptions{}); err != nil {
+			return errors.Wrapf(err, "resource creation failed - kind: %v, name: %v", kind, req.Name)
+		}
+		log.Printf("resource created - kind: %v, name: %v", kind, req.Name)
+	default:
+		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
+	}
+	return nil
 }
 
 func (c *K8s) customResourceApply(resource runtime.Object) error {
@@ -967,6 +1008,7 @@ func (c *K8s) clusterRoleBindingDelete(resource runtime.Object) error {
 	}
 	return nil
 }
+
 func (c *K8s) configMapDelete(resource runtime.Object) error {
 	req := resource.(*apiCoreV1.ConfigMap)
 	kind := resource.GetObjectKind().GroupVersionKind().Kind
@@ -1249,6 +1291,24 @@ func (c *K8s) persistentVolumeClaimDelete(resource runtime.Object) error {
 	switch v := resource.GetObjectKind().GroupVersionKind().Version; v {
 	case "v1":
 		client := c.clt.CoreV1().PersistentVolumeClaims(req.Namespace)
+		delPolicy := apiMetaV1.DeletePropagationForeground
+		if err := client.Delete(c.ctx, req.Name, apiMetaV1.DeleteOptions{PropagationPolicy: &delPolicy}); err != nil {
+			return errors.Wrapf(err, "resource delete failed - kind: %v, name: %v", kind, req.Name)
+		}
+		log.Printf("resource deleted - kind: %v , name: %v", kind, req.Name)
+	default:
+		return fmt.Errorf("unknown object version: %v kind:'%v', name:'%v'", v, kind, req.Name)
+	}
+	return nil
+}
+
+func (c *K8s) validatingWebhookConfigurationDelete(resource runtime.Object) error {
+	req := resource.(*admissionregistration.ValidatingWebhookConfiguration)
+	kind := resource.GetObjectKind().GroupVersionKind().Kind
+
+	switch v := resource.GetObjectKind().GroupVersionKind().Version; v {
+	case "v1":
+		client := c.clt.AdmissionregistrationV1().ValidatingWebhookConfigurations()
 		delPolicy := apiMetaV1.DeletePropagationForeground
 		if err := client.Delete(c.ctx, req.Name, apiMetaV1.DeleteOptions{PropagationPolicy: &delPolicy}); err != nil {
 			return errors.Wrapf(err, "resource delete failed - kind: %v, name: %v", kind, req.Name)


### PR DESCRIPTION
fixes: #718 

We aren't supporting `ValidatingWebhookConfiguration` but using it in our cluster-infra manifest files for prombench.