### PR TITLE
Remove 'consoles' from PromBench commands

### DIFF
--- a/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
@@ -66,8 +66,6 @@ spec:
         args: [
           "--web.external-url=http://{{ .DOMAIN_NAME }}/{{ .PR_NUMBER }}/prometheus-pr",
           "--storage.tsdb.path=/prometheus",
-          "--web.console.libraries=/usr/bin/console_libraries",
-          "--web.console.templates=/usr/bin/consoles",
           "--config.file=/etc/prometheus/prometheus.yml",
           "--log.level=debug"
         ]
@@ -155,8 +153,6 @@ spec:
         args: [
           "--web.external-url=http://{{ .DOMAIN_NAME }}/{{ .PR_NUMBER }}/prometheus-release",
           "--storage.tsdb.path=/prometheus",
-          "--web.console.libraries=/etc/prometheus/console_libraries",
-          "--web.console.templates=/etc/prometheus/consoles",
           "--config.file=/etc/prometheus/prometheus.yml",
           "--log.level=debug"
         ]

--- a/tools/prometheus-builder/build.sh
+++ b/tools/prometheus-builder/build.sh
@@ -32,5 +32,3 @@ fi
 
 echo ">> Copy files to volume"
 cp prometheus               $VOLUME_DIR/prometheus
-cp -r console_libraries/    $VOLUME_DIR
-cp -r consoles/             $VOLUME_DIR


### PR DESCRIPTION
Consoles are no longer supplied with Prometheus; the build step is failing because of this.