### PR TITLE
Fix up ingressClassName setting

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -257,9 +257,9 @@ kind: Ingress
 metadata:
   name: ingress-prometheus-meta
   annotations:
-    spec.ingressClassName: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:

--- a/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
+++ b/prombench/manifests/cluster-infra/7b_commentmonitor_deployment.yaml
@@ -70,9 +70,9 @@ kind: Ingress
 metadata:
   name: ingress-comment-monitor
   annotations:
-    spec.ingressClassName: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:

--- a/prombench/manifests/cluster-infra/8b_parca.yaml
+++ b/prombench/manifests/cluster-infra/8b_parca.yaml
@@ -125,9 +125,9 @@ kind: Ingress
 metadata:
   name: ingress-parca
   annotations:
-    spec.ingressClassName: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:

--- a/prombench/manifests/cluster-infra/grafana_deployment.yaml
+++ b/prombench/manifests/cluster-infra/grafana_deployment.yaml
@@ -95,9 +95,9 @@ kind: Ingress
 metadata:
   name: ingress-grafana
   annotations:
-    spec.ingressClassName: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:

--- a/prombench/manifests/prombench/benchmark/5_nginx-ingress-routes.yaml
+++ b/prombench/manifests/prombench/benchmark/5_nginx-ingress-routes.yaml
@@ -4,12 +4,12 @@ metadata:
   name: ingress-prometheus
   namespace: prombench-{{ .PR_NUMBER }}
   annotations:
-    spec.ingressClassName: "nginx"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: '605'
     nginx.ingress.kubernetes.io/proxy-send-timeout: '605'
     nginx.ingress.kubernetes.io/proxy-read-timeout: '605'
 spec:
+  ingressClassName: nginx
   rules:
   - http:
       paths:


### PR DESCRIPTION
Setting it as an annotation was a misunderstanding in #726.

I have tested this change on `ingress-prometheus` in Prombench on GKE.
