### PR TITLE
Add HTTPS Certificate to prombench.prometheus.io

### DIFF
--- a/prombench/manifests/cert-manager/1b_certificate.yaml
+++ b/prombench/manifests/cert-manager/1b_certificate.yaml
@@ -1,0 +1,12 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: prometheus-meta
+  namespace: default
+spec:
+  dnsNames:
+    - prombench.prometheus.io 
+  secretName: prombench-prometheus-tls
+  issuerRef:
+    name: letsencrypt-cluster-issuer
+    kind: ClusterIssuer

--- a/prombench/manifests/cert-manager/1c_issuer.yaml
+++ b/prombench/manifests/cert-manager/1c_issuer.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   acme:
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: vanditsinghkv@gmail.com
+    email: prometheus-team+letsencrypt@googlegroups.com
     privateKeySecretRef:
       name: letsencrypt-prod
     solvers:

--- a/prombench/manifests/cert-manager/1c_issuer.yaml
+++ b/prombench/manifests/cert-manager/1c_issuer.yaml
@@ -12,4 +12,3 @@ spec:
     - http01:
         ingress:
           class: nginx
-

--- a/prombench/manifests/cert-manager/1c_issuer.yaml
+++ b/prombench/manifests/cert-manager/1c_issuer.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-cluster-issuer
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: vanditsinghkv@gmail.com
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    solvers:
+    - http01:
+        ingress:
+          class: nginx
+

--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -242,7 +242,7 @@ metadata:
     prometheus: meta
     app: prometheus-meta
 spec:
-  type: NodePort
+  type: ClusterIP
   ports:
   - name: prom-web
     port: 80
@@ -257,9 +257,13 @@ kind: Ingress
 metadata:
   name: ingress-prometheus-meta
   annotations:
-    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
 spec:
   ingressClassName: nginx
+  tls:
+  - hosts:
+      - prombench.prometheus.io
+    secretName: prombench-prometheus-tls
   rules:
   - http:
       paths:


### PR DESCRIPTION
Fixes #724 

This PR aims to add an HTTPS certificate for `prombench.prometheus.io` using Cert-Manager and Let's Encrypt. Testing the setup locally has proven challenging. Here’s a summary of the modifications and approaches tried so far:

- Updated the Nginx `Service` type to `NodePort` from `LoadBalancer` for easier local access.
- Changed the Prometheus `Service` type to `ClusterIP` with Ingress managing external access.
- Configured the Ingress resource to handle TLS with the `prombench-prometheus-tls` secret for HTTPS.
- Modified `/etc/hosts` to map `prombench.prometheus.io` to `127.0.0.1` but it worked when I mapped it to Node IP and add the Host in the header when testing to 
- Successfully triggered and verified the ACME HTTP-01 challenge by adding the node IP to `/etc/hosts`, but the challenge does not get solved automatically with the manifest setup.

I’d appreciate any guidance on how to test this locally. The Issue was because of DNS since after mapping in `/etc/hosts` I was able to solve the challenge(Tested via curl) 
If there's a better way to test this locally. Please let me know.
Thank you!