### PR TITLE
Loki: fix compactor config

### DIFF
--- a/prombench/manifests/cluster-infra/6b_loki_stateful_set.yaml
+++ b/prombench/manifests/cluster-infra/6b_loki_stateful_set.yaml
@@ -54,6 +54,7 @@ data:
 
     compactor:
       retention_enabled: true
+      delete_request_store: filesystem
     limits_config:
       retention_period: 2184h
 ---


### PR DESCRIPTION
Extra field is mandatory when using retention.