### PR TITLE
Add remote-write to Prombench

### DIFF
--- a/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
+++ b/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
@@ -719,4 +719,4 @@ data:
         source_labels: [__meta_kubernetes_pod_node_name]
         target_label: nodeName
     remote_write:
-      - url: "http://prometheus-remote-write:80/sink/prw"  
+      - url: "http://prometheus-sink:9011/sink/prw"

--- a/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
+++ b/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
@@ -718,3 +718,5 @@ data:
       - action: replace
         source_labels: [__meta_kubernetes_pod_node_name]
         target_label: nodeName
+    remote_write:
+      - url: "http://prometheus-remote-write:80/sink/prw"  

--- a/prombench/manifests/prombench/benchmark/7_prometheus_remote_write.yaml
+++ b/prombench/manifests/prombench/benchmark/7_prometheus_remote_write.yaml
@@ -17,6 +17,13 @@ spec:
       containers:
       - name: prom-sink
         image: quay.io/bwplotka/sink:latest
+        resources:
+          limits:
+            cpu: "1"
+            memory: "350Mi"
+          requests:
+            cpu: "560m"
+            memory: "250Mi"
         imagePullPolicy: Always
         ports:
         - name: sink-port
@@ -28,14 +35,16 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-remote-write
+  name: prometheus-sink
   namespace: prombench-{{ .PR_NUMBER }}
   labels:
-    app: remote-write
+    app: sink
 spec:
+  type: ClusterIP
+  clusterIP: None
   ports:
-  - name: prometheus
-    port: 80
+  - name: sink-port
+    port: 9011
     targetPort: sink-port
   selector:
     app: sink

--- a/prombench/manifests/prombench/benchmark/7_prometheus_remote_write.yaml
+++ b/prombench/manifests/prombench/benchmark/7_prometheus_remote_write.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-sink
+  namespace: prombench-{{ .PR_NUMBER }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sink
+  template:
+    metadata:
+      namespace: prombench-{{ .PR_NUMBER }}
+      labels:
+        app: sink
+    spec:
+      containers:
+      - name: prom-sink
+        image: quay.io/bwplotka/sink:latest
+        imagePullPolicy: Always
+        ports:
+        - name: sink-port
+          containerPort: 9011
+      nodeSelector:
+        node-name: nodes-{{ .PR_NUMBER }}
+        isolation: none
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-remote-write
+  namespace: prombench-{{ .PR_NUMBER }}
+  labels:
+    app: remote-write
+spec:
+  ports:
+  - name: prometheus
+    port: 80
+    targetPort: sink-port
+  selector:
+    app: sink

--- a/prombench/manifests/prombench/benchmark/7_prometheus_remote_write.yaml
+++ b/prombench/manifests/prombench/benchmark/7_prometheus_remote_write.yaml
@@ -18,9 +18,6 @@ spec:
       - name: prom-sink
         image: quay.io/bwplotka/sink:latest
         resources:
-          limits:
-            cpu: "1"
-            memory: "350Mi"
           requests:
             cpu: "560m"
             memory: "250Mi"


### PR DESCRIPTION
### This PR introduces a Deployment and a Service to test the Prometheus Remote Write functionality.

Currently, the image for the Prometheus sink is not applied in the YAML file. To address this, I have created a basic YAML configuration that sets up the necessary Deployment and Service to test the Prometheus Remote Write functionality.

1. Deployment: A basic deployment is created to run the Prometheus sink container `(quay.io/bwplotka/sink:latest).` The container exposes port 9011 as sink-port.
2. Service: A headless ClusterIP Service is defined to expose `port 80` and forward traffic to the `sink-port` on the pods. 