### PR TITLE
Moved all workloads log.format to JSON (where it's implemented).

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -201,13 +201,14 @@ spec:
       securityContext:
         runAsUser: 0
       containers:
-      - image: quay.io/prometheus/prometheus:v2.52.0
+      - image: quay.io/prometheus/prometheus:v3.0.0
         args:
         - "--config.file=/etc/prometheus/config/prometheus.yaml"
         - "--storage.tsdb.path=/data"
         - "--storage.tsdb.retention.size=500GB"  # 50% of the total storage available.
         - "--web.enable-lifecycle"
         - "--web.external-url=http://{{ .DOMAIN_NAME }}/prometheus-meta"
+        - "--log.format=json"
         name: prometheus
         volumeMounts:
         - name: config-volume

--- a/prombench/manifests/cluster-infra/5a_alertmanager_deployment.yaml
+++ b/prombench/manifests/cluster-infra/5a_alertmanager_deployment.yaml
@@ -44,6 +44,7 @@ spec:
         - "--config.file=/etc/alertmanager/alertmanager.yml"
         - "--cluster.listen-address="
         - "--storage.path=/alertmanager"
+        - "--log.format=json"
         name: alertmanager
         volumeMounts:
         - name: config

--- a/prombench/manifests/cluster-infra/6b_loki_stateful_set.yaml
+++ b/prombench/manifests/cluster-infra/6b_loki_stateful_set.yaml
@@ -50,6 +50,7 @@ data:
       http_listen_port: 3100
       grpc_listen_port: 9096
       log_level: info
+      log_format: json
       grpc_server_max_concurrent_streams: 1000
 
     compactor:

--- a/prombench/manifests/cluster-infra/6d_promtail_daemon_set.yaml
+++ b/prombench/manifests/cluster-infra/6d_promtail_daemon_set.yaml
@@ -81,6 +81,7 @@ spec:
           args:
             - "-config.file=/etc/promtail/promtail.yaml"
             - "-client.url=http://loki:3100/api/prom/push"
+            - "-log.format=json"
           volumeMounts:
             - name: config
               mountPath: /etc/promtail

--- a/prombench/manifests/cluster-infra/8b_parca.yaml
+++ b/prombench/manifests/cluster-infra/8b_parca.yaml
@@ -81,6 +81,7 @@ spec:
           - "--config-path=/etc/parca/parca.yaml"
           - "--path-prefix=/profiles"
           - "--log-level=info"
+          - "--log.format=json"
           - "--cors-allowed-origins=*"
           - "--debuginfod-upstream-servers=https://debuginfod.systemtap.org"
           - "--debuginfod-http-request-timeout=5m"

--- a/prombench/manifests/cluster-infra/grafana_deployment.yaml
+++ b/prombench/manifests/cluster-infra/grafana_deployment.yaml
@@ -25,6 +25,8 @@ spec:
         name: grafana-core
         imagePullPolicy: IfNotPresent
         env:
+          - name: GF_LOG_FILE_FORMAT
+            value: "json"
           - name: GF_PATHS_PROVISIONING
             value: "/opt/grafana-provision"
           - name: GF_SERVER_ROOT_URL

--- a/prombench/manifests/cluster-infra/node-exporter.yaml
+++ b/prombench/manifests/cluster-infra/node-exporter.yaml
@@ -33,6 +33,7 @@ spec:
         - "--path.rootfs=/host/root"
         - "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run|home|tmp)($|/)"
         - "--collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$"
+        - "--log.format=json"
         name: node-exporter
         ports:
         - containerPort: 9100

--- a/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
@@ -68,6 +68,7 @@ spec:
           "--storage.tsdb.path=/prometheus",
           "--config.file=/etc/prometheus/prometheus.yml",
           "--log.level=debug"
+          "--log.format=json"
         ]
         volumeMounts:
         - name: config-volume

--- a/prombench/manifests/prombench/benchmark/4_node-exporter.yaml
+++ b/prombench/manifests/prombench/benchmark/4_node-exporter.yaml
@@ -50,6 +50,7 @@ spec:
         - "--path.rootfs=/host/root"
         - "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|run|home|tmp|var)($|/)"
         - "--collector.diskstats.ignored-devices=^(ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\\d+n\\d+p)\\d+$"
+        - "--log.format=json"
         name: node-exporter
         ports:
         - containerPort: 9100


### PR DESCRIPTION
This solves problem with GKE logging to assume all lines as errors.

Also updating meta Prometheus to 3.0

Once this PR is approved, I will kube apply infra resources (testing on production!)