### PR TITLE
Prombench: tweak rw-sink resource usage

### DIFF
--- a/prombench/manifests/prombench/benchmark/7_prometheus_remote_write.yaml
+++ b/prombench/manifests/prombench/benchmark/7_prometheus_remote_write.yaml
@@ -19,8 +19,14 @@ spec:
         image: quay.io/bwplotka/sink:latest
         resources:
           requests:
-            cpu: "560m"
-            memory: "250Mi"
+            cpu: "2"
+            memory: "512Mi"
+        # Trade more memory for less CPU
+        env:
+        - name: GOGC
+          value: "off"
+        - name: GOMEMLIMIT
+          value: "512MiB"
         imagePullPolicy: Always
         ports:
         - name: sink-port


### PR DESCRIPTION
Since the sink program handles a lot of messages but doesn't do anything with them, it does a lot of garbage-collection.
Tell the Go runtime we would like it to use more memory, which reduces the CPU by about half.

Adjust requests to match.


<img width="596" alt="image" src="https://github.com/user-attachments/assets/620b2d83-c884-4732-b50a-5adc97cbd274">

