### PR TITLE
Prombench: slow scraping from 5s to 15s

### DIFF
--- a/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
+++ b/prombench/manifests/prombench/benchmark/3a_prometheus-test_configmap.yaml
@@ -6,7 +6,7 @@ metadata:
 data:
   prometheus.yml: |
     global:
-      scrape_interval: 5s
+      scrape_interval: 15s
 
     scrape_configs:
     - job_name: kubelets


### PR DESCRIPTION
More realistic for end-user workloads; less expensive in cloud resources.