### PR TITLE
Prombench: add Kubernetes resource requests

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -209,6 +209,10 @@ spec:
         - "--web.enable-lifecycle"
         - "--web.external-url=http://{{ .DOMAIN_NAME }}/prometheus-meta"
         name: prometheus
+        resources:
+          requests:
+            cpu: 100m
+            memory: 1Gi
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus/config

--- a/prombench/manifests/cluster-infra/4_kube-state-metrics.yaml
+++ b/prombench/manifests/cluster-infra/4_kube-state-metrics.yaml
@@ -102,6 +102,10 @@ spec:
         image: registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.1
         args:
         - "--resources=namespaces"
+        resources:
+          requests:
+            cpu: 5m
+            memory: 20Mi
         ports:
         - name: http-metrics
           containerPort: 8080

--- a/prombench/manifests/cluster-infra/6b_loki_stateful_set.yaml
+++ b/prombench/manifests/cluster-infra/6b_loki_stateful_set.yaml
@@ -107,9 +107,10 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "-config.file=/etc/loki/loki.yaml"
-          requests:
-            cpu: 100m
-            memory: 100MB
+          resources:
+            requests:
+              cpu: 100m
+              memory: 200Mi
           volumeMounts:
             - name: config
               mountPath: /etc/loki

--- a/prombench/manifests/cluster-infra/6d_promtail_daemon_set.yaml
+++ b/prombench/manifests/cluster-infra/6d_promtail_daemon_set.yaml
@@ -81,6 +81,10 @@ spec:
           args:
             - "-config.file=/etc/promtail/promtail.yaml"
             - "-client.url=http://loki:3100/api/prom/push"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
           volumeMounts:
             - name: config
               mountPath: /etc/promtail

--- a/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
+++ b/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
@@ -35,6 +35,10 @@ data:
               containerPort: 8083
             - name: metrics5
               containerPort: 8084
+            resources:
+              requests:
+                cpu: 200m
+                memory: 60Mi
           nodeSelector:
             node-name: nodes-{{ .PR_NUMBER }}
             isolation: none
@@ -69,6 +73,10 @@ spec:
           containerPort: 8083
         - name: metrics5
           containerPort: 8084
+        resources:
+          requests:
+            cpu: 200m
+            memory: 60Mi
       nodeSelector:
         node-name: nodes-{{ .PR_NUMBER }}
         isolation: none

--- a/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3b_prometheus-test_deployment.yaml
@@ -69,6 +69,10 @@ spec:
           "--config.file=/etc/prometheus/prometheus.yml",
           "--log.level=debug"
         ]
+        resources:
+          requests:
+            cpu: 2
+            memory: 20Gi
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus
@@ -155,6 +159,10 @@ spec:
           "--config.file=/etc/prometheus/prometheus.yml",
           "--log.level=debug"
         ]
+        resources:
+          requests:
+            cpu: 2
+            memory: 20Gi
         volumeMounts:
         - name: config-volume
           mountPath: /etc/prometheus

--- a/prombench/manifests/prombench/benchmark/6_loadgen.yaml
+++ b/prombench/manifests/prombench/benchmark/6_loadgen.yaml
@@ -135,6 +135,10 @@ spec:
         env:
         - name: DOMAIN_NAME
           value: "{{ .DOMAIN_NAME }}"
+        resources:
+          requests:
+            cpu: 200m
+            memory: 100Mi
         volumeMounts:
         - name: config-volume
           mountPath: /etc/loadgen


### PR DESCRIPTION
Best to tell the system what is needed.

Specific levels based on observing at GKE, after changing scraping to 15s per #796.

I left some containers un-set, e.g. the init container that builds Prometheus.
