### PR TITLE
Fix (tmp) for prometheus-builder:master causing npm install freeze on prombench runs.

### DIFF
--- a/tools/prometheus-builder/Dockerfile
+++ b/tools/prometheus-builder/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/prometheus/golang-builder:1.23-main
+FROM quay.io/bwplotka/prom-golang-builder:1.23.6-base
 
 RUN mkdir -p /go/src/github.com
 


### PR DESCRIPTION
This custom image is locally build from https://github.com/prometheus/golang-builder/pull/296 that we agree to pause until Prometheus release. However, Prometheus release needs working prombench. This is a tmp solution until we have an official image.

Mitigates https://github.com/prometheus/test-infra/issues/832