### PR TITLE
prombench: Reduce prom logging level to info to save cloud bill.

### DIFF
--- a/prombench/manifests/prombench/benchmark/3_prometheus-test-pr_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3_prometheus-test-pr_deployment.yaml
@@ -792,7 +792,7 @@ spec:
           "--web.external-url=http://{{ .DOMAIN_NAME }}/{{ .PR_NUMBER }}/prometheus-pr",
           "--storage.tsdb.path=/prometheus",
           "--config.file=/etc/prometheus/prometheus.yml",
-          "--log.level=debug"
+          "--log.level=info"
         ]
         resources:
           requests:

--- a/prombench/manifests/prombench/benchmark/3_prometheus-test-release_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3_prometheus-test-release_deployment.yaml
@@ -766,7 +766,7 @@ spec:
           "--web.external-url=http://{{ .DOMAIN_NAME }}/{{ .PR_NUMBER }}/prometheus-release",
           "--storage.tsdb.path=/prometheus",
           "--config.file=/etc/prometheus/prometheus.yml",
-          "--log.level=debug"
+          "--log.level=info"
         ]
         resources:
           requests:


### PR DESCRIPTION
With custom benchmark anyone can rerun with debug level if needed.