### PR TITLE
Set GOMAXPROCS for benchmark binaries

### DIFF
--- a/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
+++ b/prombench/manifests/prombench/benchmark/2_fake-webserver.yaml
@@ -35,6 +35,12 @@ data:
               containerPort: 8083
             - name: metrics5
               containerPort: 8084
+            env:
+            - name: GOMAXPROCS
+              valueFrom:
+                resourceFieldRef:
+                  containerName: fake-webserver
+                  resource: requests.cpu
             resources:
               requests:
                 cpu: 200m
@@ -73,6 +79,12 @@ spec:
           containerPort: 8083
         - name: metrics5
           containerPort: 8084
+        env:
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              containerName: fake-webserver
+              resource: requests.cpu
         resources:
           requests:
             cpu: 200m

--- a/prombench/manifests/prombench/benchmark/6_loadgen.yaml
+++ b/prombench/manifests/prombench/benchmark/6_loadgen.yaml
@@ -135,6 +135,10 @@ spec:
         env:
         - name: DOMAIN_NAME
           value: "{{ .DOMAIN_NAME }}"
+        - name: GOMAXPROCS
+            resourceFieldRef:
+              containerName: fake-webserver
+              resource: requests.cpu
         resources:
           requests:
             cpu: 200m


### PR DESCRIPTION
The fake-webserver and load-generator Go binaries only request
`200m` CPU. Set a `GOMAXPROCS` to reduce the CPU scheduling contention
on the benchmark nodepool instances. Generate the value from the
resource CPU request.