### PR TITLE
Update Parca to v0.22

### DIFF
--- a/prombench/manifests/cluster-infra/8b_parca.yaml
+++ b/prombench/manifests/cluster-infra/8b_parca.yaml
@@ -74,7 +74,7 @@ spec:
         fsGroup: 65534
         runAsUser: 65534
       containers:
-      - image: ghcr.io/parca-dev/parca:v0.20.0
+      - image: ghcr.io/parca-dev/parca:v0.22.0
         args:
           - /parca
           - "--http-address=:7070"


### PR DESCRIPTION
First, let's upgrade to the lastest version.