### PR TITLE
prombench: fix initContainer ready URL to include web route prefix

### DIFF
--- a/prombench/manifests/prombench/benchmark/3_prometheus-test-release_deployment.yaml
+++ b/prombench/manifests/prombench/benchmark/3_prometheus-test-release_deployment.yaml
@@ -769,7 +769,7 @@ spec:
         - /bin/sh
         - -c
         - |
-          until wget -qO- http://prometheus-test-pr-{{ .PR_NUMBER }}/-/ready; do
+          until wget -qO- http://prometheus-test-pr-{{ .PR_NUMBER }}/{{ .PR_NUMBER }}/prometheus-pr/-/ready; do
             sleep 1
           done
       containers:


### PR DESCRIPTION
The PR Prometheus is started with --web.external-url which sets the route prefix to /<PR_NUMBER>/prometheus-pr. The /-/ready endpoint is therefore served at /<PR_NUMBER>/prometheus-pr/-/ready, not /-/ready.