### PR TITLE
prombench: use variables for cleanup file references in Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
             # don't limit this to the number of allocated cores, the job is
             # likely to get OOMed and killed.
             GOOPTS: "-p 2"
+      - run: make -C prombench check_config
   publish_infra:
     executor: golang
     steps:

--- a/prombench/Makefile
+++ b/prombench/Makefile
@@ -1,6 +1,11 @@
 INFRA_CMD  ?= ../infra/infra
 PROVIDER   ?= gke
 
+# Files used in resource_delete for cleanup. These must match actual filenames
+# in the benchmark directory.
+override CLEANUP_NAMESPACE_FILE            := 1_namespace.yaml
+override CLEANUP_CLUSTER_ROLE_BINDING_FILE := 3_cluster-role-binding.yaml
+
 cluster_create:
 	${INFRA_CMD} ${PROVIDER} cluster create -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v GKE_PROJECT_ID:${GKE_PROJECT_ID} \
@@ -97,8 +102,8 @@ resource_delete:
 	$(INFRA_CMD) ${PROVIDER} resource delete -a ${AUTH_FILE} \
 		-v ZONE:${ZONE} -v GKE_PROJECT_ID:${GKE_PROJECT_ID} \
 		-v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
-		-f ${PROMBENCH_DIR}/${BENCHMARK_DIRECTORY}/benchmark/1c_cluster-role-binding.yaml \
-		-f ${PROMBENCH_DIR}/${BENCHMARK_DIRECTORY}/benchmark/1a_namespace.yaml
+		-f ${PROMBENCH_DIR}/${BENCHMARK_DIRECTORY}/benchmark/${CLEANUP_CLUSTER_ROLE_BINDING_FILE} \
+		-f ${PROMBENCH_DIR}/${BENCHMARK_DIRECTORY}/benchmark/${CLEANUP_NAMESPACE_FILE}
 
 node_delete:
 	$(INFRA_CMD) ${PROVIDER} nodes delete -a ${AUTH_FILE} \
@@ -123,3 +128,12 @@ all_nodes_deleted:
 		-v EKS_SUBNET_IDS:${EKS_SUBNET_IDS} -v SEPARATOR:${SEPARATOR} \
 		-v CLUSTER_NAME:${CLUSTER_NAME} -v PR_NUMBER:${PR_NUMBER} \
 		-f ${PROMBENCH_DIR}/${BENCHMARK_DIRECTORY}/nodes_${PROVIDER}.yaml
+
+.PHONY: check_config
+check_config:
+	@echo ">> Checking cleanup file references"
+	@test -f ${BENCHMARK_DIRECTORY}/benchmark/${CLEANUP_NAMESPACE_FILE} || \
+		(echo "ERROR: ${BENCHMARK_DIRECTORY}/benchmark/${CLEANUP_NAMESPACE_FILE} does not exist" && exit 1)
+	@test -f ${BENCHMARK_DIRECTORY}/benchmark/${CLEANUP_CLUSTER_ROLE_BINDING_FILE} || \
+		(echo "ERROR: ${BENCHMARK_DIRECTORY}/benchmark/${CLEANUP_CLUSTER_ROLE_BINDING_FILE} does not exist" && exit 1)
+	@echo ">> All cleanup file references are valid"

--- a/prombench/manifests/prombench/README.md
+++ b/prombench/manifests/prombench/README.md
@@ -23,7 +23,7 @@ Here are an example steps:
 1. Create a new branch on https://github.com/prometheus/test-infra e.g. `benchmark/scenario1`.
 2. Modify this directory to your liking e.g. changing query load, metric load of advanced Prometheus configuration. It's also possible to make Prometheus deployments and versions exactly the same, but vary in a single configuration flag, for feature benchmarking.
 
-   > WARN: When customizing this directory, don't change `1a_namespace.yaml` or `1c_cluster-role-binding.yaml` filenames as they are used for cleanup routine. Or, if you change it, know what you're doing in relation to [`make clean` job](../../Makefile).
+   > WARN: When customizing this directory, don't change `1_namespace.yaml` or `3_cluster-role-binding.yaml` filenames as they are used for cleanup routine. Or, if you change it, know what you're doing in relation to [`make clean` job](../../Makefile).
 
 3. Push changes to the new branch.
 4. From the Prometheus PR comment, call prombench as `/prombench <release> --bench.version=benchmark/scenario1` or `/prombench <release> --bench.version=@<relevant commit SHA from the benchmark/scenario1>` to use configuration files from this custom branch.


### PR DESCRIPTION
Introduce override variables for the cleanup namespace and cluster-role-binding filenames so they are defined in one place. Update the README to reflect the current filenames and add a check_config target to validate the referenced files exist.