### PR TITLE
prombench: fix scaler broken by wave extraction and add wait parameter

### DIFF
--- a/pkg/provider/eks/eks.go
+++ b/pkg/provider/eks/eks.go
@@ -564,7 +564,7 @@ func (c *EKS) NewK8sProvider(*kingpin.ParseContext) error {
 
 // ResourceApply calls k8s.ResourceApply to apply the k8s objects in the manifest files.
 func (c *EKS) ResourceApply(*kingpin.ParseContext) error {
-	if err := c.k8sProvider.ResourceApply(c.k8sResources); err != nil {
+	if err := c.k8sProvider.ResourceApply(c.k8sResources, true); err != nil {
 		return fmt.Errorf("error while applying a resource err: %w", err)
 	}
 	return nil

--- a/pkg/provider/gke/gke.go
+++ b/pkg/provider/gke/gke.go
@@ -578,7 +578,7 @@ func (c *GKE) NewK8sProvider(*kingpin.ParseContext) error {
 
 // ResourceApply calls k8s.ResourceApply to apply the k8s objects in the manifest files.
 func (c *GKE) ResourceApply(*kingpin.ParseContext) error {
-	if err := c.k8sProvider.ResourceApply(c.k8sResources); err != nil {
+	if err := c.k8sProvider.ResourceApply(c.k8sResources, true); err != nil {
 		log.Fatal("error while applying a resource err:", err)
 	}
 	return nil

--- a/pkg/provider/k8s/k8s.go
+++ b/pkg/provider/k8s/k8s.go
@@ -146,14 +146,12 @@ func (c *K8s) DeploymentsParse(*kingpin.ParseContext) error {
 
 // ResourceApply applies k8s objects.
 // The input is a slice of structs containing the filename and the slice of k8s objects present in the file.
-func (c *K8s) ResourceApply(deployments []Resource) error {
+// If wait is true, each wave blocks until all deployments and stateful sets in it are ready.
+func (c *K8s) ResourceApply(deployments []Resource, wait bool) error {
 	// Group deployments by wave number extracted from filename prefix.
 	waves := make(map[int][]Resource)
 	for _, deployment := range deployments {
-		wave, err := extractWave(deployment.FileName)
-		if err != nil {
-			return fmt.Errorf("extracting wave from %q: %w", deployment.FileName, err)
-		}
+		wave := extractWave(deployment.FileName)
 		waves[wave] = append(waves[wave], deployment)
 	}
 
@@ -164,18 +162,18 @@ func (c *K8s) ResourceApply(deployments []Resource) error {
 	}
 	sort.Ints(waveNums)
 
-	// Apply and wait wave by wave.
+	// Apply and optionally wait wave by wave.
 	for _, wave := range waveNums {
-		if err := c.applyWave(wave, waves[wave]); err != nil {
+		if err := c.applyWave(wave, waves[wave], wait); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// applyWave applies all resources in a wave, then waits for any deployments
-// or stateful sets in that wave to become ready.
-func (c *K8s) applyWave(wave int, deployments []Resource) error {
+// applyWave applies all resources in a wave and, if wait is true, waits for
+// any deployments or stateful sets in that wave to become ready.
+func (c *K8s) applyWave(wave int, deployments []Resource, wait bool) error {
 	type pendingResource struct {
 		fileName string
 		obj      runtime.Object
@@ -255,7 +253,7 @@ func (c *K8s) applyWave(wave int, deployments []Resource) error {
 			Check: func() (bool, error) { return c.statefulSetReady(p.obj) },
 		})
 	}
-	if len(checkers) > 0 {
+	if wait && len(checkers) > 0 {
 		log.Printf("Waiting for wave %d readiness (%d resources)...", wave, len(checkers))
 		if err := provider.RetryUntilAllTrue(provider.GlobalRetryCount, checkers); err != nil {
 			return fmt.Errorf("error waiting for wave %d resources: %w", wave, err)
@@ -268,17 +266,17 @@ func (c *K8s) applyWave(wave int, deployments []Resource) error {
 // and parsing the first part as an integer.
 // For example, "path/to/4_fake-webserver.yaml" returns 4.
 // If no valid integer prefix is found, it returns 0.
-func extractWave(fileName string) (int, error) {
+func extractWave(fileName string) int {
 	base := filepath.Base(fileName)
 	parts := strings.SplitN(base, "_", 2)
 	if len(parts) < 2 {
-		return 0, fmt.Errorf("filename %q has no underscore separator", fileName)
+		return 0
 	}
 	n, err := strconv.Atoi(parts[0])
 	if err != nil {
-		return 0, fmt.Errorf("filename %q has non-numeric wave prefix %q: %w", fileName, parts[0], err)
+		return 0
 	}
-	return n, nil
+	return n
 }
 
 // ResourceDelete deletes k8s objects.

--- a/pkg/provider/k8s/k8s_test.go
+++ b/pkg/provider/k8s/k8s_test.go
@@ -17,31 +17,21 @@ import "testing"
 
 func TestExtractWave(t *testing.T) {
 	tests := []struct {
-		fileName  string
-		want      int
-		wantError bool
+		fileName string
+		want     int
 	}{
-		{"4_fake-webserver.yaml", 4, false},
-		{"path/to/5_prometheus-test-pr_deployment.yaml", 5, false},
-		{"10_loadgen.yaml", 10, false},
-		{"1_namespace.yaml", 1, false},
-		{"no_number.yaml", 0, true},
-		{"", 0, true},
-		{"nodash", 0, true},
+		{"4_fake-webserver.yaml", 4},
+		{"path/to/5_prometheus-test-pr_deployment.yaml", 5},
+		{"10_loadgen.yaml", 10},
+		{"1_namespace.yaml", 1},
+		{"no_number.yaml", 0},
+		{"", 0},
+		{"nodash", 0},
+		{"/etc/scaler/webserver.yaml", 0},
 	}
 	for _, tt := range tests {
 		t.Run(tt.fileName, func(t *testing.T) {
-			got, err := extractWave(tt.fileName)
-			if tt.wantError {
-				if err == nil {
-					t.Errorf("extractWave(%q) expected error, got nil", tt.fileName)
-				}
-				return
-			}
-			if err != nil {
-				t.Errorf("extractWave(%q) unexpected error: %v", tt.fileName, err)
-				return
-			}
+			got := extractWave(tt.fileName)
 			if got != tt.want {
 				t.Errorf("extractWave(%q) = %d, want %d", tt.fileName, got, tt.want)
 			}

--- a/pkg/provider/kind/kind.go
+++ b/pkg/provider/kind/kind.go
@@ -185,7 +185,7 @@ func (c *KIND) NewK8sProvider(*kingpin.ParseContext) error {
 
 // ResourceApply calls k8s.ResourceApply to apply the k8s objects in the manifest files.
 func (c *KIND) ResourceApply(*kingpin.ParseContext) error {
-	if err := c.k8sProvider.ResourceApply(c.k8sResources); err != nil {
+	if err := c.k8sProvider.ResourceApply(c.k8sResources, true); err != nil {
 		return err
 	}
 	return nil

--- a/tools/scaler/scaler.go
+++ b/tools/scaler/scaler.go
@@ -74,14 +74,14 @@ func (s *scale) scale(*kingpin.ParseContext) error {
 
 	for {
 		log.Printf("Scaling Deployment to %d", s.max)
-		if err := s.k8sClient.ResourceApply(maxResourceObjects); err != nil {
+		if err := s.k8sClient.ResourceApply(maxResourceObjects, false); err != nil {
 			fmt.Fprintln(os.Stderr, fmt.Errorf("Error scaling deployment: %w", err))
 		}
 
 		time.Sleep(s.interval)
 
 		log.Printf("Scaling Deployment to %d", s.min)
-		if err := s.k8sClient.ResourceApply(minResourceObjects); err != nil {
+		if err := s.k8sClient.ResourceApply(minResourceObjects, false); err != nil {
 			fmt.Fprintln(os.Stderr, fmt.Errorf("Error scaling deployment: %w", err))
 		}
 


### PR DESCRIPTION
extractWave previously returned an error for filenames without an N_ prefix, causing every ResourceApply call in the scaler to fail silently. The scaler's config file (/etc/scaler/webserver.yaml) has no wave prefix by design, so change extractWave to return 0 instead of an error for files without a numeric prefix, matching the function's documented behavior.

Also add a wait bool parameter to ResourceApply so callers can opt out of the per-wave readiness check. The scaler passes false since it only needs to patch replica counts and sleep; the infra providers (GKE, EKS, KIND) pass true to preserve the existing wave-ordered readiness behavior.