### PR TITLE
Update golangci-lint for Go 1.25 compatibility

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -28,12 +28,12 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.24.x
+          go-version: 1.25.x
       - name: Install snmp_exporter/generator dependencies
         run: sudo apt-get update && sudo apt-get -y install libsnmp-dev
         if: github.repository == 'prometheus/snmp_exporter'
       - name: Lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
           args: --verbose
-          version: v2.1.5
+          version: v2.11.3


### PR DESCRIPTION
Several dependabot PRs bump dependencies that require Go 1.25, which causes the lint CI to fail with:

```
can't load config: the Go language version (go1.24) used to build golangci-lint is lower than the targeted Go version (1.25.0)
```

This PR updates the golangci-lint workflow to unblock those PRs:

- Bump `go-version` from `1.24.x` to `1.25.x`
- Update `golangci-lint-action` from v7.0.0 to v9.2.0
- Update `golangci-lint` from v2.1.5 to v2.11.3

Blocked PRs: #849, #935, #928, #927, #926

Signed-off-by: Matthias Loibl <metalmatze@users.noreply.github.com>