### PR TITLE
prombench: upgrade prometheus-meta to v3-distroless and enable PromQL features

### DIFF
--- a/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
+++ b/prombench/manifests/cluster-infra/3b_prometheus-meta.yaml
@@ -201,13 +201,15 @@ spec:
       securityContext:
         runAsUser: 0
       containers:
-      - image: quay.io/prometheus/prometheus:v2.52.0
+      - image: quay.io/prometheus/prometheus:v3-distroless
         args:
         - "--config.file=/etc/prometheus/config/prometheus.yaml"
         - "--storage.tsdb.path=/data"
         - "--storage.tsdb.retention.size=500GB"  # 50% of the total storage available.
         - "--web.enable-lifecycle"
         - "--web.external-url=http://{{ .DOMAIN_NAME }}/prometheus-meta"
+        - "--enable-feature=promql-duration-expr"
+        - "--enable-feature=promql-extended-range-selectors"
         name: prometheus
         resources:
           requests:


### PR DESCRIPTION
Enable promql-duration-expr and promql-extended-range-selectors feature flags.